### PR TITLE
Add 相关资源 / Related resources section (HD2 guide hub companion link)

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,12 @@ npm run build
 
 安装包会生成在 `src-tauri/target/x86_64-pc-windows-msvc/release/bundle/nsis/`。
 
+
+
+## 相关资源 / Related
+
+- [Helldivers 2 Guides](https://hd2guides.com/) — Helldivers 2 stratagem tier lists, warbond guides, mission strategies, and loadout builds.
+
 ## 许可与声明
 
 本项目采用 [GNU Affero General Public License v3.0](LICENSE)（`AGPL-3.0-only`）许可。


### PR DESCRIPTION
Thanks for building this Quick Stratagem Tool — really useful during dives.

This PR adds a small `## 相关资源 / Related` section just before `## 许可与声明`, pointing to a companion HD2 guide site with stratagem tier lists, warbond guides, and mission strategies:

- [Helldivers 2 Guides](https://hd2guides.com/) — Helldivers 2 stratagem tier lists, warbond guides, mission strategies, loadout builds.

Purely additive; no existing sections modified. Happy to reword or drop.