### PR TITLE
Fix native keyboard binding regression

### DIFF
--- a/scripts/ui-regression.mjs
+++ b/scripts/ui-regression.mjs
@@ -94,6 +94,7 @@ vm.runInContext(
       canonicalGlobalKeyName,
       normalizeHotkeyChord,
       normalizeGlobalInputEvent,
+      domBindingInputFromCode,
       bindingChordFromInput,
       escapeHtml,
       safeImageSource,
@@ -108,6 +109,7 @@ const {
   canonicalGlobalKeyName,
   normalizeHotkeyChord,
   normalizeGlobalInputEvent,
+  domBindingInputFromCode,
   bindingChordFromInput,
   escapeHtml,
   safeImageSource,
@@ -135,6 +137,18 @@ assert.deepEqual(
   ["ControlLeft", "ShiftLeft", "KeyW", "Digit1"],
   "binding should keep the newest input as the trigger and order held requirements consistently",
 );
+const domPressedKeys = new Set();
+assert.deepEqual(
+  JSON.parse(JSON.stringify(domBindingInputFromCode("ControlLeft", domPressedKeys))),
+  { key: "ControlLeft", pressedInputs: ["ControlLeft"] },
+);
+const domChordInput = domBindingInputFromCode("KeyW", domPressedKeys);
+assert.deepEqual(
+  JSON.parse(JSON.stringify(bindingChordFromInput(domChordInput))),
+  ["ControlLeft", "KeyW"],
+  "focused-window keyboard capture must preserve held keys for chord binding",
+);
+assert.equal(domBindingInputFromCode("NotAKey", domPressedKeys), null);
 assert.equal(escapeHtml('<img src=x onerror="boom">'), "&lt;img src=x onerror=&quot;boom&quot;&gt;");
 assert.equal(safeImageSource("Machine_Gun_Stratagem_Icon.svg"), "Machine_Gun_Stratagem_Icon.svg");
 assert.equal(safeImageSource("javascript:alert(1)"), "empty-image");
@@ -300,6 +314,15 @@ assert.doesNotMatch(indexSource, /function\s+triggerMacro\s*\(/, "JavaScript mus
 assert.match(hooksSource, /impl\s+ShortcutState[\s\S]*fn\s+route\s*\(/);
 assert.match(hooksSource, /input::prepare_macro\(&binding\.payload\)/);
 assert.match(inputSource, /struct\s+PreparedMacro/);
+assert.match(inputSource, /dwExtraInfo:\s*SYNTHETIC_INPUT_MARKER/g);
+assert.match(hooksSource, /extra_info\s*==\s*input::SYNTHETIC_INPUT_MARKER/);
+assert.match(indexSource, /addEventListener\('keydown',\s*handleKeyInput\)/);
+assert.match(indexSource, /addEventListener\('keyup',\s*handleKeyUp\)/);
+assert.match(
+  indexSource,
+  /function\s+handleKeyInput\(e\)[\s\S]{0,500}domBindingInputFromCode\(e\.code,[\s\S]{0,300}captureBindingInput\(input\)/,
+  "focused keyboard events must reach the binding state machine",
+);
 assert.match(mainSource, /fn\s+get_input_diagnostics\s*\(/);
 assert.match(indexSource, /if \(isOverlayVisible\) \{[\s\S]*gameSettings\.ovExec/);
 assert.match(indexSource, /directionOnly:\s*false/, "direction-only mode must be opt-in");

--- a/src-tauri/src/hooks.rs
+++ b/src-tauri/src/hooks.rs
@@ -40,6 +40,8 @@ static NATIVE_MACROS_STARTED: AtomicU64 = AtomicU64::new(0);
 static NATIVE_MACROS_SUPPRESSED: AtomicU64 = AtomicU64::new(0);
 static NATIVE_ACTIONS_ROUTED: AtomicU64 = AtomicU64::new(0);
 static BINDING_EVENTS_FORWARDED: AtomicU64 = AtomicU64::new(0);
+static OWN_SYNTHETIC_EVENTS_IGNORED: AtomicU64 = AtomicU64::new(0);
+static EXTERNAL_INJECTED_EVENTS_ACCEPTED: AtomicU64 = AtomicU64::new(0);
 static FILTER_INITIALIZED: AtomicBool = AtomicBool::new(false);
 static CAPTURE_ALL_INPUTS: AtomicBool = AtomicBool::new(true);
 static KEY_FILTER: [AtomicU64; 4] = [const { AtomicU64::new(0) }; 4];
@@ -205,6 +207,8 @@ pub struct InputDiagnostics {
     native_macros_suppressed: u64,
     native_actions_routed: u64,
     binding_events_forwarded: u64,
+    own_synthetic_events_ignored: u64,
+    external_injected_events_accepted: u64,
 }
 
 pub fn start(app: AppHandle) -> Result<(), String> {
@@ -316,6 +320,9 @@ pub fn diagnostics() -> InputDiagnostics {
         native_macros_suppressed: NATIVE_MACROS_SUPPRESSED.load(Ordering::Relaxed),
         native_actions_routed: NATIVE_ACTIONS_ROUTED.load(Ordering::Relaxed),
         binding_events_forwarded: BINDING_EVENTS_FORWARDED.load(Ordering::Relaxed),
+        own_synthetic_events_ignored: OWN_SYNTHETIC_EVENTS_IGNORED.load(Ordering::Relaxed),
+        external_injected_events_accepted: EXTERNAL_INJECTED_EVENTS_ACCEPTED
+            .load(Ordering::Relaxed),
     }
 }
 
@@ -993,7 +1000,12 @@ unsafe extern "system" fn keyboard_hook(code: i32, wparam: WPARAM, lparam: LPARA
         // specifies that `lparam` points to a `KBDLLHOOKSTRUCT` which remains
         // valid for the duration of this callback; the null case was excluded.
         let event = unsafe { &*(lparam.0 as *const KBDLLHOOKSTRUCT) };
-        if !is_injected_keyboard(event.flags.0) {
+        if should_ignore_keyboard_event(event.flags.0, event.dwExtraInfo) {
+            OWN_SYNTHETIC_EVENTS_IGNORED.fetch_add(1, Ordering::Relaxed);
+        } else {
+            if event.flags.0 & LLKHF_INJECTED_FLAG != 0 {
+                EXTERNAL_INJECTED_EVENTS_ACCEPTED.fetch_add(1, Ordering::Relaxed);
+            }
             if let Some(key) = key_name(event.vkCode, event.scanCode, event.flags.0) {
                 let state_code = pressed_state_code(key, event.vkCode);
                 match wparam.0 as u32 {
@@ -1036,10 +1048,14 @@ unsafe extern "system" fn mouse_hook(code: i32, wparam: WPARAM, lparam: LPARAM) 
         // that `lparam` points to an `MSLLHOOKSTRUCT` valid until this callback
         // returns; the null case was explicitly excluded above.
         let event = unsafe { &*(lparam.0 as *const MSLLHOOKSTRUCT) };
-        if is_injected_mouse(event.flags) {
+        if should_ignore_mouse_event(event.flags, event.dwExtraInfo) {
+            OWN_SYNTHETIC_EVENTS_IGNORED.fetch_add(1, Ordering::Relaxed);
             // SAFETY: these are the unchanged arguments supplied by Windows;
             // the hook handle is ignored by `CallNextHookEx`, so `None` is valid.
             return unsafe { CallNextHookEx(None, code, wparam, lparam) };
+        }
+        if event.flags & LLMHF_INJECTED_FLAG != 0 {
+            EXTERNAL_INJECTED_EVENTS_ACCEPTED.fetch_add(1, Ordering::Relaxed);
         }
         match wparam.0 as u32 {
             WM_MBUTTONDOWN => {
@@ -1151,12 +1167,12 @@ fn queue_event(event: InputEvent) {
     }
 }
 
-fn is_injected_keyboard(flags: u32) -> bool {
-    flags & LLKHF_INJECTED_FLAG != 0
+fn should_ignore_keyboard_event(flags: u32, extra_info: usize) -> bool {
+    flags & LLKHF_INJECTED_FLAG != 0 && extra_info == input::SYNTHETIC_INPUT_MARKER
 }
 
-fn is_injected_mouse(flags: u32) -> bool {
-    flags & LLMHF_INJECTED_FLAG != 0
+fn should_ignore_mouse_event(flags: u32, extra_info: usize) -> bool {
+    flags & LLMHF_INJECTED_FLAG != 0 && extra_info == input::SYNTHETIC_INPUT_MARKER
 }
 
 fn key_name(vk: u32, scan_code: u32, flags: u32) -> Option<&'static str> {
@@ -1591,10 +1607,24 @@ mod tests {
     }
 
     #[test]
-    fn ignores_input_generated_by_send_input() {
-        assert!(is_injected_keyboard(LLKHF_INJECTED_FLAG));
-        assert!(is_injected_mouse(LLMHF_INJECTED_FLAG));
-        assert!(!is_injected_keyboard(0));
-        assert!(!is_injected_mouse(0));
+    fn ignores_only_input_generated_by_this_process() {
+        assert!(should_ignore_keyboard_event(
+            LLKHF_INJECTED_FLAG,
+            input::SYNTHETIC_INPUT_MARKER
+        ));
+        assert!(should_ignore_mouse_event(
+            LLMHF_INJECTED_FLAG,
+            input::SYNTHETIC_INPUT_MARKER
+        ));
+
+        // Third-party injected input can be legitimate input from keyboard
+        // drivers, remappers, remote desktops, and accessibility software.
+        assert!(!should_ignore_keyboard_event(LLKHF_INJECTED_FLAG, 0));
+        assert!(!should_ignore_mouse_event(LLMHF_INJECTED_FLAG, 0));
+        assert!(!should_ignore_keyboard_event(
+            0,
+            input::SYNTHETIC_INPUT_MARKER
+        ));
+        assert!(!should_ignore_mouse_event(0, input::SYNTHETIC_INPUT_MARKER));
     }
 }

--- a/src-tauri/src/input.rs
+++ b/src-tauri/src/input.rs
@@ -25,6 +25,11 @@ static MACRO_SHUTTING_DOWN: AtomicBool = AtomicBool::new(false);
 static MACRO_SIGNAL: OnceLock<(Mutex<()>, Condvar)> = OnceLock::new();
 const MAX_DELAY_MS: u64 = 60_000;
 const MAX_MACRO_DURATION_MS: u64 = 300_000;
+// Tag every SendInput event created by this process. The low-level hooks use
+// this marker to suppress only our own macro output instead of rejecting all
+// injected input from keyboard drivers, remappers, remote desktops, or
+// accessibility software.
+pub(crate) const SYNTHETIC_INPUT_MARKER: usize = 0x4844_3253;
 
 /// Returns true for virtual key codes that require the KEYEVENTF_EXTENDEDKEY
 /// flag. Without it, arrow keys / navigation keys are indistinguishable from
@@ -400,19 +405,7 @@ fn key_up(key: VIRTUAL_KEY) -> Result<(), String> {
 fn send_key(key: VIRTUAL_KEY, flags: KEYBD_EVENT_FLAGS) -> Result<(), String> {
     // Use scancodes like nut-js does — many games (including HD2) ignore
     // SendInput events that only carry a virtual key code without a scancode.
-    let (virtual_key, scan_code, full_flags) = keyboard_event_components(key, flags);
-    let input = INPUT {
-        r#type: INPUT_KEYBOARD,
-        Anonymous: INPUT_0 {
-            ki: KEYBDINPUT {
-                wVk: virtual_key,
-                wScan: scan_code,
-                dwFlags: full_flags,
-                time: 0,
-                dwExtraInfo: 0,
-            },
-        },
-    };
+    let input = keyboard_input(key, flags);
     // SAFETY: the INPUT discriminant is INPUT_KEYBOARD and the matching `ki`
     // union field is fully initialized. The one-element slice remains valid for
     // the call, and `cbSize` is the exact size Windows requires for INPUT.
@@ -423,6 +416,24 @@ fn send_key(key: VIRTUAL_KEY, flags: KEYBD_EVENT_FLAGS) -> Result<(), String> {
         Err(format!(
             "Windows rejected synthetic keyboard input ({sent}/1 events sent). Ensure the game and trigger run at the same privilege level"
         ))
+    }
+}
+
+fn keyboard_input(key: VIRTUAL_KEY, flags: KEYBD_EVENT_FLAGS) -> INPUT {
+    // Many games (including HD2) ignore SendInput events that carry only a
+    // virtual-key code, so preserve the existing scan-code based input path.
+    let (virtual_key, scan_code, full_flags) = keyboard_event_components(key, flags);
+    INPUT {
+        r#type: INPUT_KEYBOARD,
+        Anonymous: INPUT_0 {
+            ki: KEYBDINPUT {
+                wVk: virtual_key,
+                wScan: scan_code,
+                dwFlags: full_flags,
+                time: 0,
+                dwExtraInfo: SYNTHETIC_INPUT_MARKER,
+            },
+        },
     }
 }
 
@@ -514,20 +525,7 @@ fn scan_code(virtual_key: u16) -> u16 {
 }
 
 fn send_mouse_button(button: MouseButton, release: bool) -> Result<(), String> {
-    let (flags, mouse_data) = mouse_event(button, release);
-    let input = INPUT {
-        r#type: INPUT_MOUSE,
-        Anonymous: INPUT_0 {
-            mi: MOUSEINPUT {
-                dx: 0,
-                dy: 0,
-                mouseData: mouse_data,
-                dwFlags: flags,
-                time: 0,
-                dwExtraInfo: 0,
-            },
-        },
-    };
+    let input = mouse_button_input(button, release);
     // SAFETY: the INPUT discriminant is INPUT_MOUSE and the matching `mi` union
     // field is fully initialized. The one-element slice remains valid for the
     // call, and `cbSize` is the exact size Windows requires for INPUT.
@@ -538,6 +536,23 @@ fn send_mouse_button(button: MouseButton, release: bool) -> Result<(), String> {
         Err(format!(
             "Windows rejected synthetic mouse input ({sent}/1 events sent). Ensure the game and trigger run at the same privilege level"
         ))
+    }
+}
+
+fn mouse_button_input(button: MouseButton, release: bool) -> INPUT {
+    let (flags, mouse_data) = mouse_event(button, release);
+    INPUT {
+        r#type: INPUT_MOUSE,
+        Anonymous: INPUT_0 {
+            mi: MOUSEINPUT {
+                dx: 0,
+                dy: 0,
+                mouseData: mouse_data,
+                dwFlags: flags,
+                time: 0,
+                dwExtraInfo: SYNTHETIC_INPUT_MARKER,
+            },
+        },
     }
 }
 
@@ -737,6 +752,19 @@ mod tests {
             input_key("NumpadEnter"),
             Some(InputKey::ExtendedKeyboard(VK_RETURN))
         );
+    }
+
+    #[test]
+    fn tags_every_synthetic_input_with_the_private_marker() {
+        let keyboard = keyboard_input(VIRTUAL_KEY(b'W' as u16), KEYBD_EVENT_FLAGS(0));
+        let mouse = mouse_button_input(MouseButton::Side1, false);
+
+        // SAFETY: both helper functions set the INPUT discriminant and the
+        // matching union member together immediately before these reads.
+        unsafe {
+            assert_eq!(keyboard.Anonymous.ki.dwExtraInfo, SYNTHETIC_INPUT_MARKER);
+            assert_eq!(mouse.Anonymous.mi.dwExtraInfo, SYNTHETIC_INPUT_MARKER);
+        }
     }
 
     #[test]

--- a/ui/index.html
+++ b/ui/index.html
@@ -974,6 +974,7 @@
         let maxSlots = DEFAULT_SLOT_COUNT;
         let bindingTarget = null;
         let bindingFilterTransition = false;
+        const bindingDomPressedKeys = new Set();
         let isOverlayVisible = false; 
         let ocrDisplays = [];
         let pendingUpdateInfo = null;
@@ -1059,6 +1060,13 @@
             }
             pressedInputs.push(key);
             return { key, pressedInputs };
+        }
+
+        function domBindingInputFromCode(code, pressedKeys) {
+            const key = canonicalGlobalKeyName(code);
+            if (!key || !pressedKeys || typeof pressedKeys.add !== 'function') return null;
+            pressedKeys.add(key);
+            return { key, pressedInputs: [...pressedKeys] };
         }
 
         function bindingChordFromInput(value) {
@@ -2298,6 +2306,7 @@
 
         function attachListeners() { 
             window.addEventListener('keydown', handleKeyInput); 
+            window.addEventListener('keyup', handleKeyUp);
             window.addEventListener('mousedown', handleMouseInput); 
             syncGlobalInputFilter();
         }
@@ -2305,7 +2314,17 @@
         function handleKeyInput(e) {
             e.preventDefault();
             e.stopPropagation();
-            if (e.code === 'Escape') settleBindingTransition(() => cancelBinding());
+            if (e.repeat || !bindingTarget) return;
+            const input = domBindingInputFromCode(e.code, bindingDomPressedKeys);
+            if (input) captureBindingInput(input);
+        }
+
+        function handleKeyUp(e) {
+            if (!bindingTarget) return;
+            e.preventDefault();
+            e.stopPropagation();
+            const key = canonicalGlobalKeyName(e.code);
+            if (key) bindingDomPressedKeys.delete(key);
         }
 
         function handleMouseInput(e) {
@@ -2327,7 +2346,9 @@
                 needsRender = true;
             }
             bindingTarget = null; 
+            bindingDomPressedKeys.clear();
             window.removeEventListener('keydown', handleKeyInput); 
+            window.removeEventListener('keyup', handleKeyUp);
             window.removeEventListener('mousedown', handleMouseInput);
             if (needsRender && render) renderMainList(); 
             updateSettingsUI();
@@ -2679,8 +2700,16 @@
             if (bindingTarget) captureBindingInput(inputValue);
         }
 
+        function handleGlobalKeyboardInput(inputValue) {
+            // The focused binding UI owns keyboard capture. Ignore the matching
+            // low-level-hook event here so one physical edge is never recorded
+            // twice; mouse and wheel bindings still use the native hook.
+            if (bindingTarget && document.hasFocus()) return;
+            handleGlobalInput(inputValue);
+        }
+
         if (window.electronAPI) {
-            if (window.electronAPI.onGlobalKeyDown) window.electronAPI.onGlobalKeyDown(handleGlobalInput);
+            if (window.electronAPI.onGlobalKeyDown) window.electronAPI.onGlobalKeyDown(handleGlobalKeyboardInput);
             if (window.electronAPI.onGlobalMouseDown) window.electronAPI.onGlobalMouseDown(handleGlobalInput);
             if (window.electronAPI.onGlobalWheel) window.electronAPI.onGlobalWheel(handleGlobalInput);
             if (window.electronAPI.onNativeShortcut) window.electronAPI.onNativeShortcut(({ action } = {}) => {


### PR DESCRIPTION
## 改动内容

- 为程序自身通过 `SendInput` 产生的键盘和鼠标事件添加专用标记。
- 原生全局钩子只过滤带有该标记的自身输入，不再误杀键盘驱动、重映射工具、远程桌面或辅助输入产生的合法事件。
- 恢复主窗口聚焦时的键盘绑定捕获，并跟踪按下/松开状态以支持单键与组合键。
- 增加原生输入诊断计数和键盘绑定回归测试。

## 根因与影响

2.0.1 将绑定捕获迁移到 Rust 原生钩子后，统一丢弃了所有被 Windows 标记为“注入”的键盘事件，同时窗口内的键盘捕获不再保存普通按键。部分用户因此只能绑定鼠标和侧键，无法修改战备或 OCR 键盘快捷键。

本修复从输入源上区分“程序自身模拟输入”和“用户环境产生的合法输入”，既恢复键盘绑定，也继续避免宏输出递归触发自身快捷键。

Fixes #9

## 验证

- `npm run check`
- `npm test`：Rust 60 passed，0 failed；UI/OCR 回归通过
- `npm run build:bundle`
- 真实 Tauri WebView：F8 单键、Ctrl+W 组合键、OCR 快捷键绑定通过
- 原生链路：外部注入输入成功路由；宏仅启动一次，自身 11 个模拟边沿全部过滤，0 丢包