### PR TITLE
新增隐私安全的诊断中心

### DIFF
--- a/scripts/ui-regression.mjs
+++ b/scripts/ui-regression.mjs
@@ -298,6 +298,63 @@ assert.match(
   "display enumeration failures must not erase a saved OCR region",
 );
 const bridgeSource = readUiFile("bridge.js");
+assert.match(indexSource, /id="btn-top-diagnostics"[^>]*onclick="openDiagnostics\(\)"/);
+assert.match(indexSource, /id="diagnostics-modal"[^>]*role="dialog"[^>]*aria-modal="true"/);
+assert.match(indexSource, /id="btn-diagnostics-export"[^>]*onclick="exportDiagnosticsReport\(\)"/);
+assert.match(indexSource, /No usernames, full paths, hotkey values, stratagem names, or screenshots/);
+assert.match(bridgeSource, /collectDiagnosticsReport:.*collect_diagnostics_report/);
+assert.match(bridgeSource, /exportDiagnosticsReport:.*export_diagnostics_report/);
+assert.match(mainSource, /async fn\s+collect_diagnostics_report\s*\(/);
+assert.match(mainSource, /async fn\s+export_diagnostics_report\s*\(/);
+
+const diagnosticI18nStart = indexSource.indexOf("const diagnosticsI18n = {");
+const diagnosticI18nEnd = indexSource.indexOf("const defaultStratagemDB", diagnosticI18nStart);
+const diagnosticHelperStart = indexSource.indexOf("function fillDiagnosticTemplate");
+const diagnosticHelperEnd = indexSource.indexOf("function updateDiagnosticsI18n", diagnosticHelperStart);
+assert.notEqual(diagnosticI18nStart, -1, "could not find diagnostics translations");
+assert.notEqual(diagnosticI18nEnd, -1, "could not find diagnostics translations end marker");
+assert.notEqual(diagnosticHelperStart, -1, "could not find diagnostic health helpers");
+assert.notEqual(diagnosticHelperEnd, -1, "could not find diagnostic health helper end marker");
+const diagnosticContext = vm.createContext({});
+vm.runInContext(
+  `
+    ${indexSource.slice(diagnosticI18nStart, diagnosticI18nEnd)}
+    let currentLang = "en";
+    ${indexSource.slice(diagnosticHelperStart, diagnosticHelperEnd)}
+    globalThis.diagnosticsHarness = { buildDiagnosticChecks, summarizeDiagnosticChecks };
+  `,
+  diagnosticContext,
+  { filename: "index.html:diagnostic-health" },
+);
+const healthyReport = {
+  application: { version: "2.0.1", architecture: "x86_64", webviewVersion: "140.0" },
+  storage: { writable: true, invalidFileCount: 0, recoverableBackupCount: 0, files: [{ status: "valid" }] },
+  configuration: { settingsLoaded: true, slotCount: 10, equippedStratagems: 4, boundStratagems: 3, presetCount: 2, duplicateBindingGroups: 0 },
+  input: { hookRunning: true, filterInitialized: true, droppedEvents: 0, maxQueueDepth: 2, queueCapacity: 512, processedEvents: 20 },
+  ocr: {
+    modelFilesPresent: true,
+    selfTest: { ok: true, value: { detectionModelLoaded: true, recognitionModelLoaded: true, dictionaryEntries: 1000 } },
+    displays: { ok: true, value: { displayCount: 1, primaryWidth: 1920, primaryHeight: 1080, primaryScaleFactor: 1 } },
+  },
+  windows: { mainWindowExists: true, overlayWindowExists: false, overlayLocked: false },
+  updateService: { reachable: true, validResponse: true, latestVersion: "2.0.1", latencyMs: 50 },
+};
+const healthyChecks = diagnosticContext.diagnosticsHarness.buildDiagnosticChecks(healthyReport, "en");
+assert.equal(healthyChecks.length, 10);
+assert.deepEqual(
+  JSON.parse(JSON.stringify(diagnosticContext.diagnosticsHarness.summarizeDiagnosticChecks(healthyChecks))),
+  { healthy: 10, warnings: 0, errors: 0 },
+);
+const unhealthyReport = structuredClone(healthyReport);
+unhealthyReport.updateService = { reachable: false, validResponse: false, error: "offline" };
+unhealthyReport.input.droppedEvents = 2;
+unhealthyReport.ocr.modelFilesPresent = false;
+unhealthyReport.storage.invalidFileCount = 1;
+const unhealthySummary = diagnosticContext.diagnosticsHarness.summarizeDiagnosticChecks(
+  diagnosticContext.diagnosticsHarness.buildDiagnosticChecks(unhealthyReport, "zh"),
+);
+assert.deepEqual(JSON.parse(JSON.stringify(unhealthySummary)), { healthy: 6, warnings: 2, errors: 2 });
+
 assert.match(bridgeSource, /subscribe\("quit-requested", callback\)/);
 assert.match(indexSource, /window\.electronAPI\.onQuitRequested/);
 assert.match(bridgeSource, /setGlobalInputFilter:\s*\(config, captureAll\).*set_global_input_filter/);
@@ -514,5 +571,8 @@ assert.deepEqual(bridgeCalls, ["begin_exit", "window_close"]);
 await bridgeContext.window.electronAPI.checkForUpdates();
 await bridgeContext.window.electronAPI.openReleaseDownload();
 assert.deepEqual(bridgeCalls.slice(-2), ["check_for_updates", "open_release_download"]);
+await bridgeContext.window.electronAPI.collectDiagnosticsReport();
+await bridgeContext.window.electronAPI.exportDiagnosticsReport({ schemaVersion: 1 });
+assert.deepEqual(bridgeCalls.slice(-2), ["collect_diagnostics_report", "export_diagnostics_report"]);
 
 console.log(`UI, native-window, and ${new Set(bundledIcons).size} icon regression tests passed.`);

--- a/src-tauri/src/diagnostics.rs
+++ b/src-tauri/src/diagnostics.rs
@@ -1,0 +1,571 @@
+use crate::{config, hooks, ocr, updates};
+use serde::Serialize;
+use serde_json::Value;
+use std::{
+    collections::HashMap,
+    fs::{self, OpenOptions},
+    io::Write,
+    path::{Path, PathBuf},
+    time::{SystemTime, UNIX_EPOCH},
+};
+
+const MAX_EXPORTED_REPORT_BYTES: usize = 256 * 1024;
+
+#[derive(Clone, Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ApplicationDiagnostics {
+    pub version: String,
+    pub build_profile: &'static str,
+    pub operating_system: &'static str,
+    pub architecture: &'static str,
+    pub webview_version: Option<String>,
+    pub process_id: u32,
+}
+
+#[derive(Clone, Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct WindowDiagnostics {
+    pub main_window_exists: bool,
+    pub main_window_visible: bool,
+    pub overlay_window_exists: bool,
+    pub overlay_window_visible: bool,
+    pub overlay_locked: bool,
+}
+
+#[derive(Clone, Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct FileDiagnostics {
+    pub name: &'static str,
+    pub status: &'static str,
+    pub size_bytes: Option<u64>,
+    pub entry_count: Option<usize>,
+    pub backup_available: bool,
+    pub issue: Option<String>,
+}
+
+#[derive(Clone, Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct StorageDiagnostics {
+    pub directory_ready: bool,
+    pub writable: bool,
+    pub invalid_file_count: usize,
+    pub recoverable_backup_count: usize,
+    pub files: Vec<FileDiagnostics>,
+    pub issue: Option<String>,
+}
+
+#[derive(Clone, Debug, Default, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ConfigurationDiagnostics {
+    pub settings_loaded: bool,
+    pub slot_count: usize,
+    pub equipped_stratagems: usize,
+    pub bound_stratagems: usize,
+    pub preset_count: usize,
+    pub custom_stratagem_count: usize,
+    pub duplicate_binding_groups: usize,
+    pub ocr_region_configured: bool,
+    pub ocr_display_configured: bool,
+    pub direction_only: bool,
+    pub toast_notifications: bool,
+    pub auto_open_overlay: bool,
+    pub auto_lock_overlay: bool,
+}
+
+#[derive(Clone, Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct StaticOcrDiagnostics {
+    pub model_files_present: bool,
+    pub self_test: DiagnosticResult<ocr::ModelStatus>,
+    pub displays: DiagnosticResult<DisplayDiagnostics>,
+}
+
+#[derive(Clone, Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DisplayDiagnostics {
+    pub display_count: usize,
+    pub primary_width: Option<u32>,
+    pub primary_height: Option<u32>,
+    pub primary_scale_factor: Option<f32>,
+}
+
+#[derive(Clone, Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DiagnosticResult<T> {
+    pub ok: bool,
+    pub value: Option<T>,
+    pub error: Option<String>,
+}
+
+impl<T> DiagnosticResult<T> {
+    pub fn success(value: T) -> Self {
+        Self {
+            ok: true,
+            value: Some(value),
+            error: None,
+        }
+    }
+
+    pub fn failure(error: String) -> Self {
+        Self {
+            ok: false,
+            value: None,
+            error: Some(error),
+        }
+    }
+}
+
+#[derive(Clone, Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct LocalDiagnostics {
+    pub application: ApplicationDiagnostics,
+    pub windows: WindowDiagnostics,
+    pub storage: StorageDiagnostics,
+    pub configuration: ConfigurationDiagnostics,
+    pub migration: config::MigrationReport,
+    pub input: hooks::InputDiagnostics,
+    pub ocr_model_files_present: bool,
+}
+
+#[derive(Clone, Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DiagnosticReport {
+    pub schema_version: u8,
+    pub generated_at_unix_ms: u128,
+    pub application: ApplicationDiagnostics,
+    pub windows: WindowDiagnostics,
+    pub storage: StorageDiagnostics,
+    pub configuration: ConfigurationDiagnostics,
+    pub migration: config::MigrationReport,
+    pub input: hooks::InputDiagnostics,
+    pub ocr: StaticOcrDiagnostics,
+    pub update_service: updates::UpdateEndpointDiagnostics,
+    pub privacy: PrivacyDiagnostics,
+}
+
+#[derive(Clone, Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PrivacyDiagnostics {
+    pub includes_user_names: bool,
+    pub includes_full_paths: bool,
+    pub includes_hotkey_values: bool,
+    pub includes_stratagem_names: bool,
+    pub includes_screenshots: bool,
+}
+
+#[derive(Clone, Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ExportResult {
+    pub filename: String,
+}
+
+pub fn collect_local(
+    data_dir: &Path,
+    ocr_model_dir: &Path,
+    migration: config::MigrationReport,
+    windows: WindowDiagnostics,
+) -> LocalDiagnostics {
+    let (storage, values) = inspect_storage(data_dir);
+    LocalDiagnostics {
+        application: ApplicationDiagnostics {
+            version: env!("CARGO_PKG_VERSION").to_owned(),
+            build_profile: if cfg!(debug_assertions) {
+                "debug"
+            } else {
+                "release"
+            },
+            operating_system: std::env::consts::OS,
+            architecture: std::env::consts::ARCH,
+            webview_version: tauri::webview_version().ok(),
+            process_id: std::process::id(),
+        },
+        windows,
+        configuration: summarize_configuration(&values),
+        storage,
+        migration,
+        input: hooks::diagnostics(),
+        ocr_model_files_present: ocr::model_files_exist(ocr_model_dir),
+    }
+}
+
+pub fn assemble_report(
+    local: LocalDiagnostics,
+    ocr_self_test: Result<ocr::ModelStatus, String>,
+    displays: Result<Vec<ocr::OcrDisplay>, String>,
+    update_service: updates::UpdateEndpointDiagnostics,
+    redacted_roots: &[PathBuf],
+) -> DiagnosticReport {
+    let ocr_self_test = match ocr_self_test {
+        Ok(status) => DiagnosticResult::success(status),
+        Err(error) => DiagnosticResult::failure(sanitize_error(&error, redacted_roots)),
+    };
+    let displays = match displays {
+        Ok(displays) => {
+            let primary = displays
+                .iter()
+                .find(|display| display.is_primary)
+                .or_else(|| displays.first());
+            DiagnosticResult::success(DisplayDiagnostics {
+                display_count: displays.len(),
+                primary_width: primary.map(|display| display.bounds.width),
+                primary_height: primary.map(|display| display.bounds.height),
+                primary_scale_factor: primary.map(|display| display.scale_factor),
+            })
+        }
+        Err(error) => DiagnosticResult::failure(sanitize_error(&error, redacted_roots)),
+    };
+    DiagnosticReport {
+        schema_version: 1,
+        generated_at_unix_ms: unix_time_millis(),
+        application: local.application,
+        windows: local.windows,
+        storage: local.storage,
+        configuration: local.configuration,
+        migration: local.migration,
+        input: local.input,
+        ocr: StaticOcrDiagnostics {
+            model_files_present: local.ocr_model_files_present,
+            self_test: ocr_self_test,
+            displays,
+        },
+        update_service,
+        privacy: PrivacyDiagnostics {
+            includes_user_names: false,
+            includes_full_paths: false,
+            includes_hotkey_values: false,
+            includes_stratagem_names: false,
+            includes_screenshots: false,
+        },
+    }
+}
+
+pub fn export_report(download_dir: &Path, report: &Value) -> Result<ExportResult, String> {
+    if report.get("schemaVersion").and_then(Value::as_u64) != Some(1) {
+        return Err("Unsupported diagnostics report schema".to_owned());
+    }
+    let bytes = serde_json::to_vec_pretty(report)
+        .map_err(|error| format!("Cannot serialize diagnostics report: {error}"))?;
+    if bytes.len() > MAX_EXPORTED_REPORT_BYTES {
+        return Err("Diagnostics report exceeds the 256 KiB limit".to_owned());
+    }
+    fs::create_dir_all(download_dir)
+        .map_err(|error| format!("Cannot prepare the Downloads folder: {error}"))?;
+    let timestamp = unix_time_millis();
+    let (filename, path, mut file) = (0_u8..100)
+        .find_map(|suffix| {
+            let filename = if suffix == 0 {
+                format!("HD2-Diagnostics-{timestamp}.json")
+            } else {
+                format!("HD2-Diagnostics-{timestamp}-{suffix}.json")
+            };
+            let path = download_dir.join(&filename);
+            match OpenOptions::new().create_new(true).write(true).open(&path) {
+                Ok(file) => Some(Ok((filename, path, file))),
+                Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => None,
+                Err(error) => Some(Err(error)),
+            }
+        })
+        .transpose()
+        .map_err(|error| format!("Cannot create the diagnostics report: {error}"))?
+        .ok_or_else(|| "Cannot allocate a unique diagnostics report filename".to_owned())?;
+    if let Err(error) = file
+        .write_all(&bytes)
+        .and_then(|_| file.flush())
+        .and_then(|_| file.sync_all())
+    {
+        drop(file);
+        let _ = fs::remove_file(path);
+        return Err(format!("Cannot finish the diagnostics report: {error}"));
+    }
+    Ok(ExportResult { filename })
+}
+
+fn inspect_storage(data_dir: &Path) -> (StorageDiagnostics, HashMap<&'static str, Value>) {
+    let directory_ready = data_dir.is_dir();
+    let (writable, issue) = test_directory_writable(data_dir);
+    let mut values = HashMap::new();
+    let mut files = Vec::with_capacity(config::LEGACY_FILES.len());
+    for filename in config::LEGACY_FILES {
+        let path = data_dir.join(filename);
+        let backup_available = path.with_extension("json.backup").is_file();
+        if !path.is_file() {
+            files.push(FileDiagnostics {
+                name: filename,
+                status: "missing",
+                size_bytes: None,
+                entry_count: None,
+                backup_available,
+                issue: None,
+            });
+            continue;
+        }
+        let size_bytes = fs::metadata(&path).ok().map(|metadata| metadata.len());
+        match config::load_json(data_dir, filename) {
+            Ok(Some(value)) => {
+                let entry_count = match &value {
+                    Value::Array(items) => Some(items.len()),
+                    Value::Object(items) => Some(items.len()),
+                    _ => None,
+                };
+                values.insert(filename, value);
+                files.push(FileDiagnostics {
+                    name: filename,
+                    status: "valid",
+                    size_bytes,
+                    entry_count,
+                    backup_available,
+                    issue: None,
+                });
+            }
+            Ok(None) => unreachable!("the file existence check already succeeded"),
+            Err(error) => files.push(FileDiagnostics {
+                name: filename,
+                status: "invalid",
+                size_bytes,
+                entry_count: None,
+                backup_available,
+                issue: Some(sanitize_error(&error, &[data_dir.to_owned()])),
+            }),
+        }
+    }
+    let invalid_file_count = files.iter().filter(|file| file.status == "invalid").count();
+    let recoverable_backup_count = files
+        .iter()
+        .filter(|file| file.status == "invalid" && file.backup_available)
+        .count();
+    (
+        StorageDiagnostics {
+            directory_ready,
+            writable,
+            invalid_file_count,
+            recoverable_backup_count,
+            files,
+            issue,
+        },
+        values,
+    )
+}
+
+fn summarize_configuration(values: &HashMap<&'static str, Value>) -> ConfigurationDiagnostics {
+    let settings = values.get("settings.json").and_then(Value::as_object);
+    let loadout = values.get("loadout.json").and_then(Value::as_array);
+    let presets = values.get("presets.json").and_then(Value::as_array);
+    let custom = values.get("custom_strats.json").and_then(Value::as_array);
+    let mut binding_counts = HashMap::<&str, usize>::new();
+    let mut equipped_stratagems = 0;
+    let mut bound_stratagems = 0;
+    if let Some(loadout) = loadout {
+        for item in loadout.iter().filter_map(Value::as_object) {
+            if item.get("stratId").is_some_and(|value| !value.is_null()) {
+                equipped_stratagems += 1;
+            }
+            if let Some(binding) = item
+                .get("hotkey")
+                .and_then(Value::as_str)
+                .map(str::trim)
+                .filter(|binding| !binding.is_empty())
+            {
+                bound_stratagems += 1;
+                *binding_counts.entry(binding).or_default() += 1;
+            }
+        }
+    }
+    if let Some(binding) = settings
+        .and_then(|settings| settings.get("ocrHotkey"))
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|binding| !binding.is_empty())
+    {
+        *binding_counts.entry(binding).or_default() += 1;
+    }
+    ConfigurationDiagnostics {
+        settings_loaded: settings.is_some(),
+        slot_count: settings
+            .and_then(|settings| settings.get("slotCount"))
+            .and_then(Value::as_u64)
+            .and_then(|count| usize::try_from(count).ok())
+            .or_else(|| loadout.map(Vec::len))
+            .unwrap_or(0),
+        equipped_stratagems,
+        bound_stratagems,
+        preset_count: presets.map(Vec::len).unwrap_or(0),
+        custom_stratagem_count: custom.map(Vec::len).unwrap_or(0),
+        duplicate_binding_groups: binding_counts.values().filter(|count| **count > 1).count(),
+        ocr_region_configured: settings
+            .and_then(|settings| settings.get("ocrRegion"))
+            .is_some_and(|value| value.is_object()),
+        ocr_display_configured: settings
+            .and_then(|settings| settings.get("ocrDisplayId"))
+            .is_some_and(|value| !value.is_null()),
+        direction_only: setting_bool(settings, "directionOnly", false),
+        toast_notifications: setting_bool(settings, "showToasts", true),
+        auto_open_overlay: setting_bool(settings, "autoOpenOverlay", false),
+        auto_lock_overlay: setting_bool(settings, "autoLockOverlay", false),
+    }
+}
+
+fn setting_bool(
+    settings: Option<&serde_json::Map<String, Value>>,
+    key: &str,
+    fallback: bool,
+) -> bool {
+    settings
+        .and_then(|settings| settings.get(key))
+        .and_then(Value::as_bool)
+        .unwrap_or(fallback)
+}
+
+fn test_directory_writable(data_dir: &Path) -> (bool, Option<String>) {
+    if !data_dir.is_dir() {
+        return (
+            false,
+            Some("Application data directory is missing".to_owned()),
+        );
+    }
+    let probe = data_dir.join(format!(
+        ".diagnostics-write-probe-{}-{}",
+        std::process::id(),
+        unix_time_nanos()
+    ));
+    let result = (|| -> std::io::Result<()> {
+        let mut file = OpenOptions::new()
+            .create_new(true)
+            .write(true)
+            .open(&probe)?;
+        file.write_all(b"diagnostics")?;
+        file.flush()?;
+        file.sync_all()?;
+        drop(file);
+        fs::remove_file(&probe)
+    })();
+    match result {
+        Ok(()) => (true, None),
+        Err(error) => {
+            let _ = fs::remove_file(probe);
+            (
+                false,
+                Some(sanitize_error(
+                    &format!("Application data directory is not writable: {error}"),
+                    &[data_dir.to_owned()],
+                )),
+            )
+        }
+    }
+}
+
+pub fn sanitize_error(error: &str, redacted_roots: &[PathBuf]) -> String {
+    let mut sanitized = error.replace(['\r', '\n', '\t'], " ");
+    for root in redacted_roots {
+        let rendered = root.to_string_lossy();
+        if !rendered.is_empty() {
+            sanitized = sanitized.replace(rendered.as_ref(), "<redacted-path>");
+        }
+    }
+    sanitized.chars().take(320).collect()
+}
+
+fn unix_time_millis() -> u128 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|duration| duration.as_millis())
+        .unwrap_or(0)
+}
+
+fn unix_time_nanos() -> u128 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|duration| duration.as_nanos())
+        .unwrap_or(0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn temporary_directory(label: &str) -> PathBuf {
+        let path = std::env::temp_dir().join(format!(
+            "hd2-diagnostics-{label}-{}-{}",
+            std::process::id(),
+            unix_time_millis()
+        ));
+        fs::create_dir_all(&path).expect("temporary directory should be creatable");
+        path
+    }
+
+    #[test]
+    fn storage_report_contains_statuses_but_not_file_contents_or_paths() {
+        let directory = temporary_directory("storage");
+        fs::write(
+            directory.join("settings.json"),
+            br#"{"menuKey":"SecretKey","directionOnly":true}"#,
+        )
+        .expect("settings should be writable");
+        fs::write(directory.join("loadout.json"), b"{broken")
+            .expect("invalid loadout should be writable");
+
+        let (report, _) = inspect_storage(&directory);
+        let serialized = serde_json::to_string(&report).expect("report should serialize");
+        assert!(report.writable);
+        assert_eq!(report.invalid_file_count, 1);
+        assert!(!serialized.contains("SecretKey"));
+        assert!(!serialized.contains(directory.to_string_lossy().as_ref()));
+        fs::remove_dir_all(directory).expect("temporary directory should be removable");
+    }
+
+    #[test]
+    fn configuration_summary_counts_bindings_without_exporting_values() {
+        let mut values = HashMap::new();
+        values.insert(
+            "settings.json",
+            serde_json::json!({
+                "slotCount": 4,
+                "ocrHotkey": "F8",
+                "directionOnly": true,
+                "ocrRegion": {"x": 10, "y": 20, "width": 30, "height": 40}
+            }),
+        );
+        values.insert(
+            "loadout.json",
+            serde_json::json!([
+                {"stratId": "secret-one", "hotkey": "F8"},
+                {"stratId": "secret-two", "hotkey": "F9"}
+            ]),
+        );
+
+        let summary = summarize_configuration(&values);
+        let serialized = serde_json::to_string(&summary).expect("summary should serialize");
+        assert_eq!(summary.equipped_stratagems, 2);
+        assert_eq!(summary.bound_stratagems, 2);
+        assert_eq!(summary.duplicate_binding_groups, 1);
+        assert!(summary.direction_only);
+        assert!(summary.ocr_region_configured);
+        assert!(!serialized.contains("secret-one"));
+        assert!(!serialized.contains("F8"));
+    }
+
+    #[test]
+    fn export_rejects_unknown_or_oversized_reports() {
+        let directory = temporary_directory("export");
+        assert!(export_report(&directory, &serde_json::json!({"schemaVersion": 2})).is_err());
+        let oversized = "x".repeat(MAX_EXPORTED_REPORT_BYTES);
+        assert!(export_report(
+            &directory,
+            &serde_json::json!({"schemaVersion": 1, "payload": oversized})
+        )
+        .is_err());
+        fs::remove_dir_all(directory).expect("temporary directory should be removable");
+    }
+
+    #[test]
+    fn export_creates_a_pretty_printed_report_without_overwriting() {
+        let directory = temporary_directory("export-success");
+        let report = serde_json::json!({"schemaVersion": 1, "healthSummary": {"errors": 0}});
+        let first = export_report(&directory, &report).expect("first report should export");
+        let second = export_report(&directory, &report).expect("second report should export");
+        assert_ne!(first.filename, second.filename);
+        let contents = fs::read_to_string(directory.join(first.filename))
+            .expect("exported report should be readable");
+        assert!(contents.contains("\n  \"schemaVersion\": 1"));
+        fs::remove_dir_all(directory).expect("temporary directory should be removable");
+    }
+}

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -2,6 +2,7 @@
 
 mod capture;
 mod config;
+mod diagnostics;
 mod hooks;
 mod input;
 mod legacy;
@@ -233,6 +234,85 @@ fn set_global_input_filter(config: hooks::ShortcutConfig, capture_all: bool) -> 
 #[tauri::command]
 fn get_input_diagnostics() -> hooks::InputDiagnostics {
     hooks::diagnostics()
+}
+
+#[tauri::command]
+async fn collect_diagnostics_report(
+    app: AppHandle,
+    state: State<'_, AppState>,
+) -> Result<diagnostics::DiagnosticReport, String> {
+    let data_dir = state.data_dir.clone();
+    let ocr_model_dir = state.ocr_model_dir.clone();
+    let migration_report = state.migration_report.clone();
+    let overlay_locked = state
+        .overlay_snapshot
+        .lock()
+        .map_err(|_| "Overlay state is unavailable".to_owned())?
+        .locked;
+    let main_window = app.get_webview_window("main");
+    let overlay_window = app.get_webview_window("overlay");
+    let window_diagnostics = diagnostics::WindowDiagnostics {
+        main_window_exists: main_window.is_some(),
+        main_window_visible: main_window
+            .as_ref()
+            .and_then(|window| window.is_visible().ok())
+            .unwrap_or(false),
+        overlay_window_exists: overlay_window.is_some(),
+        overlay_window_visible: overlay_window
+            .as_ref()
+            .and_then(|window| window.is_visible().ok())
+            .unwrap_or(false),
+        overlay_locked,
+    };
+
+    let local_data_dir = data_dir.clone();
+    let local_model_dir = ocr_model_dir.clone();
+    let local_task = tauri::async_runtime::spawn_blocking(move || {
+        diagnostics::collect_local(
+            &local_data_dir,
+            &local_model_dir,
+            migration_report,
+            window_diagnostics,
+        )
+    });
+    let update_task = tauri::async_runtime::spawn_blocking(updates::diagnose_endpoint);
+    let display_task = tauri::async_runtime::spawn_blocking(ocr::available_displays);
+    let ocr_app = app.clone();
+    let ocr_task = tauri::async_runtime::spawn(async move { ocr_model_status(ocr_app).await });
+
+    let local = local_task
+        .await
+        .map_err(|error| format!("Local diagnostics task failed: {error}"))?;
+    let ocr_self_test = ocr_task
+        .await
+        .unwrap_or_else(|error| Err(format!("OCR diagnostics task failed: {error}")));
+    let displays = display_task
+        .await
+        .unwrap_or_else(|error| Err(format!("Display diagnostics task failed: {error}")));
+    let update_service = update_task
+        .await
+        .map_err(|error| format!("Update diagnostics task failed: {error}"))?;
+    Ok(diagnostics::assemble_report(
+        local,
+        ocr_self_test,
+        displays,
+        update_service,
+        &[data_dir, ocr_model_dir],
+    ))
+}
+
+#[tauri::command]
+async fn export_diagnostics_report(
+    app: AppHandle,
+    report: Value,
+) -> Result<diagnostics::ExportResult, String> {
+    let download_dir = app
+        .path()
+        .download_dir()
+        .map_err(|error| format!("Cannot locate the Downloads folder: {error}"))?;
+    tauri::async_runtime::spawn_blocking(move || diagnostics::export_report(&download_dir, &report))
+        .await
+        .map_err(|error| format!("Diagnostics export task failed: {error}"))?
 }
 
 #[tauri::command]
@@ -771,6 +851,8 @@ fn main() {
             migration_status,
             set_global_input_filter,
             get_input_diagnostics,
+            collect_diagnostics_report,
+            export_diagnostics_report,
             toggle_overlay,
             window_minimize,
             window_tray,

--- a/src-tauri/src/ocr.rs
+++ b/src-tauri/src/ocr.rs
@@ -110,7 +110,7 @@ fn resolve_runtime_path(model_dir: &Path) -> PathBuf {
         .unwrap_or_else(|| model_dir.join(RUNTIME_LIBRARY))
 }
 
-#[derive(Serialize)]
+#[derive(Clone, Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ModelStatus {
     pub detection_model_loaded: bool,

--- a/src-tauri/src/updates.rs
+++ b/src-tauri/src/updates.rs
@@ -1,6 +1,6 @@
 use semver::Version;
 use serde::{Deserialize, Serialize};
-use std::{ffi::c_void, mem::size_of, ptr};
+use std::{ffi::c_void, mem::size_of, ptr, time::Instant};
 use windows::{
     core::{w, Error as WindowsError, PCWSTR},
     Win32::{
@@ -26,6 +26,18 @@ pub struct UpdateInfo {
     pub current_version: String,
     pub version: String,
     pub release_name: Option<String>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct UpdateEndpointDiagnostics {
+    pub endpoint_host: &'static str,
+    pub reachable: bool,
+    pub valid_response: bool,
+    pub latest_version: Option<String>,
+    pub update_available: Option<bool>,
+    pub latency_ms: u128,
+    pub error: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -71,6 +83,46 @@ impl Drop for WinHttpHandle {
 pub fn check_for_update() -> Result<Option<UpdateInfo>, String> {
     let payload = fetch_latest_release()?;
     available_update(&payload, env!("CARGO_PKG_VERSION"))
+}
+
+pub fn diagnose_endpoint() -> UpdateEndpointDiagnostics {
+    let started = Instant::now();
+    match fetch_latest_release() {
+        Ok(payload) => match parse_release_tag(&payload.tag_name) {
+            Ok(version) => {
+                let update_available = available_update(&payload, env!("CARGO_PKG_VERSION"))
+                    .ok()
+                    .map(|update| update.is_some());
+                UpdateEndpointDiagnostics {
+                    endpoint_host: UPDATE_ENDPOINT_HOST,
+                    reachable: true,
+                    valid_response: true,
+                    latest_version: Some(version.to_string()),
+                    update_available,
+                    latency_ms: started.elapsed().as_millis(),
+                    error: None,
+                }
+            }
+            Err(error) => UpdateEndpointDiagnostics {
+                endpoint_host: UPDATE_ENDPOINT_HOST,
+                reachable: true,
+                valid_response: false,
+                latest_version: None,
+                update_available: None,
+                latency_ms: started.elapsed().as_millis(),
+                error: Some(compact_error(&error)),
+            },
+        },
+        Err(error) => UpdateEndpointDiagnostics {
+            endpoint_host: UPDATE_ENDPOINT_HOST,
+            reachable: false,
+            valid_response: false,
+            latest_version: None,
+            update_available: None,
+            latency_ms: started.elapsed().as_millis(),
+            error: Some(compact_error(&error)),
+        },
+    }
 }
 
 pub fn open_releases_page() -> Result<(), String> {
@@ -252,6 +304,14 @@ fn wide_null(value: &str) -> Vec<u16> {
     value.encode_utf16().chain(std::iter::once(0)).collect()
 }
 
+fn compact_error(error: &str) -> String {
+    error
+        .replace(['\r', '\n', '\t'], " ")
+        .chars()
+        .take(320)
+        .collect()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -295,6 +355,14 @@ mod tests {
         let mut prerelease = payload("v.3.0.0-beta.1");
         prerelease.prerelease = true;
         assert!(available_update(&prerelease, "2.0.1").unwrap().is_none());
+    }
+
+    #[test]
+    fn endpoint_diagnostics_error_text_is_single_line_and_bounded() {
+        let error = format!("first\r\nsecond\t{}", "x".repeat(500));
+        let compact = compact_error(&error);
+        assert!(!compact.contains(['\r', '\n', '\t']));
+        assert!(compact.chars().count() <= 320);
     }
 
     #[test]

--- a/ui/bridge.js
+++ b/ui/bridge.js
@@ -27,6 +27,8 @@
     onQuitRequested: (callback) => subscribe("quit-requested", callback),
     setGlobalInputFilter: (config, captureAll) => invoke("set_global_input_filter", { config, captureAll }),
     getInputDiagnostics: () => invoke("get_input_diagnostics"),
+    collectDiagnosticsReport: () => invoke("collect_diagnostics_report"),
+    exportDiagnosticsReport: (report) => invoke("export_diagnostics_report", { report }),
     onNativeShortcut: (callback) => subscribe("native-shortcut", callback),
     onNativeMacroStarted: (callback) => subscribe("native-macro-started", callback),
     onNativeMacroFinished: (callback) => subscribe("native-macro-finished", callback),

--- a/ui/index.html
+++ b/ui/index.html
@@ -321,6 +321,83 @@
         .file-upload-btn:hover { background: var(--hd-yellow-alpha); color: var(--hd-yellow); border-color: var(--hd-yellow); }
         #add-strat-preview { width: 44px; height: 44px; object-fit: contain; border: 1px solid var(--glass-border); border-radius: var(--radius-sm); background: rgba(0,0,0,0.5); display: none; padding: 4px; }
         .hint-text { font-size: 12px; color: var(--hd-text-secondary); text-align: center; margin-top: 12px; line-height: 1.6; }
+
+        .diagnostics-content {
+            width: 100%; max-width: 980px; margin: 0 auto; padding: 24px;
+            display: flex; flex-direction: column; gap: 18px; overflow-y: auto;
+        }
+        .diagnostics-content > * { flex-shrink: 0; }
+        .diagnostics-intro {
+            position: relative; overflow: hidden; padding: 22px 24px;
+            background: linear-gradient(135deg, rgba(255,232,10,0.10), rgba(28,28,30,0.72) 42%, rgba(28,28,30,0.52));
+            border: 1px solid rgba(255,232,10,0.22); border-radius: var(--radius-lg);
+            box-shadow: 0 10px 30px rgba(0,0,0,0.24);
+        }
+        .diagnostics-intro::after {
+            content: ''; position: absolute; width: 180px; height: 180px; right: -70px; top: -110px;
+            border: 1px solid rgba(255,232,10,0.18); border-radius: 50%; box-shadow: 0 0 60px rgba(255,232,10,0.08);
+        }
+        .diagnostics-kicker { color: var(--hd-yellow); font-size: 10px; font-weight: 800; letter-spacing: 2px; margin-bottom: 8px; }
+        .diagnostics-intro h2 { font-size: 20px; line-height: 1.25; margin-bottom: 8px; }
+        .diagnostics-intro p { color: var(--hd-text-secondary); font-size: 12px; line-height: 1.65; max-width: 720px; }
+        .diagnostics-privacy { margin-top: 12px; color: rgba(255,255,255,0.72); font-size: 11px; }
+        .diagnostics-privacy::before { content: '◇'; color: var(--hd-yellow); margin-right: 8px; }
+
+        .diagnostics-health-rail { display: grid; grid-template-columns: repeat(3, minmax(0, 1fr)); gap: 12px; }
+        .diagnostics-meter {
+            min-height: 90px; padding: 16px 18px; border-radius: var(--radius-md);
+            background: rgba(20,20,22,0.78); border: 1px solid var(--glass-border);
+            display: flex; align-items: center; gap: 14px; box-shadow: 0 6px 18px rgba(0,0,0,0.18);
+        }
+        .diagnostics-meter-value { font-size: 30px; font-weight: 850; font-variant-numeric: tabular-nums; line-height: 1; }
+        .diagnostics-meter-label { display: block; font-size: 12px; color: var(--hd-text-secondary); margin-top: 5px; letter-spacing: 0.4px; }
+        .diagnostics-meter.ok { border-left: 4px solid #32d583; }
+        .diagnostics-meter.ok .diagnostics-meter-value { color: #55e69c; }
+        .diagnostics-meter.warning { border-left: 4px solid var(--hd-yellow); }
+        .diagnostics-meter.warning .diagnostics-meter-value { color: var(--hd-yellow); }
+        .diagnostics-meter.error { border-left: 4px solid var(--hd-red); }
+        .diagnostics-meter.error .diagnostics-meter-value { color: #ff6961; }
+
+        .diagnostics-meta {
+            display: flex; justify-content: space-between; align-items: center; gap: 12px;
+            color: var(--hd-text-secondary); font-size: 11px; padding: 0 2px;
+        }
+        .diagnostics-running { color: var(--hd-yellow); display: none; align-items: center; gap: 8px; }
+        .diagnostics-running.active { display: flex; }
+        .diagnostics-running::before { content: ''; width: 7px; height: 7px; border-radius: 50%; background: var(--hd-yellow); animation: diagnosticPulse 1.2s ease-in-out infinite; }
+        @keyframes diagnosticPulse { 50% { opacity: 0.25; transform: scale(0.72); } }
+
+        .diagnostics-grid { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 14px; }
+        .diagnostics-section {
+            background: var(--glass-panel); border: 1px solid var(--glass-border); border-radius: var(--radius-lg);
+            overflow: hidden; box-shadow: 0 8px 24px rgba(0,0,0,0.18);
+        }
+        .diagnostics-section-title {
+            padding: 14px 18px; font-size: 12px; font-weight: 800; letter-spacing: 0.9px;
+            color: rgba(255,255,255,0.82); border-bottom: 1px solid var(--glass-border); background: rgba(0,0,0,0.18);
+        }
+        .diagnostics-check { display: grid; grid-template-columns: 10px minmax(0,1fr); gap: 12px; padding: 15px 18px; border-bottom: 1px solid rgba(255,255,255,0.045); }
+        .diagnostics-check:last-child { border-bottom: 0; }
+        .diagnostics-check-dot { width: 8px; height: 8px; border-radius: 50%; margin-top: 5px; background: var(--hd-text-secondary); box-shadow: 0 0 0 4px rgba(255,255,255,0.035); }
+        .diagnostics-check.ok .diagnostics-check-dot { background: #32d583; box-shadow: 0 0 0 4px rgba(50,213,131,0.09); }
+        .diagnostics-check.warning .diagnostics-check-dot { background: var(--hd-yellow); box-shadow: 0 0 0 4px rgba(255,232,10,0.09); }
+        .diagnostics-check.error .diagnostics-check-dot { background: var(--hd-red); box-shadow: 0 0 0 4px rgba(255,69,58,0.11); }
+        .diagnostics-check-title { font-size: 13px; font-weight: 700; line-height: 1.35; }
+        .diagnostics-check-summary { margin-top: 4px; color: var(--hd-text-secondary); font-size: 11px; line-height: 1.5; word-break: break-word; user-select: text; }
+        .diagnostics-empty { grid-column: 1 / -1; padding: 42px 24px; text-align: center; color: var(--hd-text-secondary); border: 1px dashed var(--glass-border); border-radius: var(--radius-lg); }
+        .diagnostics-actions { display: flex; justify-content: flex-end; gap: 10px; padding-bottom: 4px; }
+        .diagnostics-actions .btn-square { flex-grow: 0; min-width: 150px; }
+        .diagnostics-header-actions { display: flex; gap: 10px; }
+
+        @media (max-width: 760px) {
+            .diagnostics-grid { grid-template-columns: 1fr; }
+            .diagnostics-health-rail { gap: 8px; }
+            .diagnostics-meter { padding: 13px; min-height: 76px; }
+            .diagnostics-meter-value { font-size: 24px; }
+        }
+        @media (prefers-reduced-motion: reduce) {
+            .diagnostics-running::before { animation: none; }
+        }
     </style>
 </head>
 <body>
@@ -339,6 +416,7 @@
         <div class="top-controls">
             <button class="btn-square" id="btn-top-settings" onclick="openSettings()">GAME SETTINGS</button>
             <button class="btn-square" id="btn-top-presets" onclick="openPresets()">PRESETS</button>
+            <button class="btn-square" id="btn-top-diagnostics" onclick="openDiagnostics()">DIAGNOSTICS</button>
             <button class="btn-square" id="btn-top-overlay" onclick="handleToggleOverlay()">OVERLAY</button>
             <button class="btn-square primary" id="btn-top-lib" onclick="openLibrary()">OPEN LIBRARY</button>
         </div>
@@ -590,6 +668,51 @@
                     </div>
                     <button class="set-btn" id="btn-set-rightKey" onclick="startSettingBind('rightKey', event)">D</button>
                 </div>
+            </div>
+        </div>
+    </div>
+
+    <div id="diagnostics-modal" class="modal-overlay" role="dialog" aria-modal="true" aria-labelledby="txt-diagnostics-title">
+        <div class="modal-header">
+            <div class="modal-title" id="txt-diagnostics-title">DIAGNOSTICS CENTER</div>
+            <div class="diagnostics-header-actions">
+                <button class="btn-square" id="btn-diagnostics-refresh" onclick="refreshDiagnostics()">RUN AGAIN</button>
+                <button class="btn-square" id="btn-diagnostics-close" onclick="closeDiagnostics()">CLOSE</button>
+            </div>
+        </div>
+        <div class="diagnostics-content">
+            <section class="diagnostics-intro">
+                <div class="diagnostics-kicker">SYSTEM READINESS</div>
+                <h2 id="txt-diagnostics-lead">Turn a vague problem into reproducible evidence.</h2>
+                <p id="txt-diagnostics-description">One run checks local storage, global input, OCR, displays, windows, and the update service.</p>
+                <div class="diagnostics-privacy" id="txt-diagnostics-privacy">No usernames, full paths, hotkey values, stratagem names, or screenshots are included.</div>
+            </section>
+
+            <div class="diagnostics-health-rail" aria-live="polite">
+                <div class="diagnostics-meter ok">
+                    <div class="diagnostics-meter-value" id="diagnostics-ok-count">0</div>
+                    <div class="diagnostics-meter-label" id="txt-diagnostics-ok">HEALTHY</div>
+                </div>
+                <div class="diagnostics-meter warning">
+                    <div class="diagnostics-meter-value" id="diagnostics-warning-count">0</div>
+                    <div class="diagnostics-meter-label" id="txt-diagnostics-warning">WARNINGS</div>
+                </div>
+                <div class="diagnostics-meter error">
+                    <div class="diagnostics-meter-value" id="diagnostics-error-count">0</div>
+                    <div class="diagnostics-meter-label" id="txt-diagnostics-error">ERRORS</div>
+                </div>
+            </div>
+
+            <div class="diagnostics-meta">
+                <span id="diagnostics-generated-at">NOT RUN YET</span>
+                <span class="diagnostics-running" id="diagnostics-running">RUNNING CHECKS...</span>
+            </div>
+            <div class="diagnostics-grid" id="diagnostics-sections">
+                <div class="diagnostics-empty" id="diagnostics-empty">Run diagnostics to inspect the application.</div>
+            </div>
+            <div class="diagnostics-actions">
+                <button class="btn-square" id="btn-diagnostics-copy" onclick="copyDiagnosticsReport()">COPY REPORT</button>
+                <button class="btn-square primary" id="btn-diagnostics-export" onclick="exportDiagnosticsReport()">EXPORT TO DOWNLOADS</button>
             </div>
         </div>
     </div>
@@ -876,6 +999,57 @@
             }
         };
 
+        const diagnosticsI18n = {
+            zh: {
+                button: "诊断中心", title: "诊断中心", refresh: "重新检测", close: "关闭",
+                lead: "把模糊的问题，变成可复现的证据。",
+                description: "一次检查本地存储、全局输入、OCR、显示器、窗口和更新服务。各项相互独立，单项失败不会中断整份报告。",
+                privacy: "不包含用户名、完整路径、快捷键内容、战备名称或屏幕截图。",
+                healthy: "正常", warnings: "提醒", errors: "异常", running: "正在执行检查...",
+                notRun: "尚未检测", generated: "报告生成于 {time}", empty: "运行诊断后将在这里显示应用状态。",
+                copy: "复制报告", export: "导出到下载目录", copySuccess: "诊断报告已复制",
+                exportSuccess: "诊断报告已导出到 下载/{filename}", runFailed: "诊断执行失败：{error}",
+                copyFailed: "复制诊断报告失败", exportFailed: "导出诊断报告失败：{error}",
+                sectionSystem: "应用与本地数据", sectionInput: "全局输入链路", sectionOcr: "OCR 与显示器", sectionServices: "窗口与在线服务",
+                runtimeTitle: "运行环境", runtimeOk: "版本 {version} · {arch} · WebView2 {webview}",
+                storageTitle: "配置存储", storageOk: "数据目录可写，{valid} 个配置文件有效。", storageFailed: "数据目录不可写：{error}",
+                filesTitle: "配置完整性", filesOk: "未发现损坏的配置文件。", filesInvalid: "发现 {count} 个无效配置文件，其中 {recoverable} 个有可恢复备份。",
+                configTitle: "配置摘要", configOk: "{equipped}/{slots} 个栏位已装备，{bound} 个战备已绑定，{presets} 个预设。",
+                configMissing: "设置文件尚未建立；首次保存设置后会自动创建。", configDuplicate: "检测到 {count} 组重复绑定，请检查快捷键冲突。",
+                hookTitle: "全局输入钩子", hookOk: "输入钩子与快捷键过滤器均已运行。", hookWaiting: "输入钩子已运行，但快捷键过滤器尚未完成初始化。", hookFailed: "全局输入钩子未运行。",
+                queueTitle: "输入事件队列", queueOk: "已处理 {processed} 个事件；峰值队列 {maxDepth}/{capacity}，无丢失。", queueDropped: "已有 {dropped} 个输入事件丢失；峰值队列 {maxDepth}/{capacity}。", queueBusy: "输入队列峰值达到 {maxDepth}/{capacity}，建议在问题发生后再次导出报告。",
+                modelsTitle: "OCR 模型", modelsOk: "检测与识别模型已成功加载，字典包含 {entries} 项。", modelsMissing: "OCR 模型文件不完整。", modelsFailed: "OCR 自检失败：{error}",
+                displaysTitle: "显示器枚举", displaysOk: "检测到 {count} 块屏幕；主屏幕 {width}×{height}，缩放 {scale}。", displaysFailed: "显示器检查失败：{error}", displaysNone: "Windows 未返回可用显示器。",
+                windowsTitle: "窗口状态", windowsOk: "主窗口正常；悬浮窗{overlay}，当前{lockState}。", windowsFailed: "主窗口状态不可用。", overlayOpen: "已创建", overlayClosed: "未创建（正常）", locked: "已锁定", unlocked: "未锁定",
+                updateTitle: "更新服务", updateOk: "update.unsnow.online 响应有效，最新版本 {version}，耗时 {latency} ms。", updateFailed: "更新服务暂时不可用：{error}", updateInvalid: "更新服务可以连接，但返回内容无效：{error}",
+                unavailable: "不可用", unknown: "未知"
+            },
+            en: {
+                button: "DIAGNOSTICS", title: "DIAGNOSTICS CENTER", refresh: "RUN AGAIN", close: "CLOSE",
+                lead: "Turn a vague problem into reproducible evidence.",
+                description: "One run checks local storage, global input, OCR, displays, windows, and the update service. Checks remain independent if one fails.",
+                privacy: "No usernames, full paths, hotkey values, stratagem names, or screenshots are included.",
+                healthy: "HEALTHY", warnings: "WARNINGS", errors: "ERRORS", running: "RUNNING CHECKS...",
+                notRun: "NOT RUN YET", generated: "Report generated at {time}", empty: "Run diagnostics to inspect the application.",
+                copy: "COPY REPORT", export: "EXPORT TO DOWNLOADS", copySuccess: "Diagnostics report copied",
+                exportSuccess: "Diagnostics report exported to Downloads/{filename}", runFailed: "Diagnostics failed: {error}",
+                copyFailed: "Could not copy the diagnostics report", exportFailed: "Could not export the diagnostics report: {error}",
+                sectionSystem: "APPLICATION & LOCAL DATA", sectionInput: "GLOBAL INPUT PIPELINE", sectionOcr: "OCR & DISPLAYS", sectionServices: "WINDOWS & ONLINE SERVICE",
+                runtimeTitle: "Runtime", runtimeOk: "Version {version} · {arch} · WebView2 {webview}",
+                storageTitle: "Configuration storage", storageOk: "Data directory is writable; {valid} configuration files are valid.", storageFailed: "Data directory is not writable: {error}",
+                filesTitle: "Configuration integrity", filesOk: "No damaged configuration files were found.", filesInvalid: "Found {count} invalid configuration files; {recoverable} have a recovery backup.",
+                configTitle: "Configuration summary", configOk: "{equipped}/{slots} slots equipped, {bound} stratagem bindings, {presets} presets.",
+                configMissing: "The settings file has not been created yet; it will be created after the first save.", configDuplicate: "Found {count} duplicate binding groups. Check for hotkey conflicts.",
+                hookTitle: "Global input hook", hookOk: "The input hook and shortcut filter are running.", hookWaiting: "The input hook is running, but the shortcut filter has not finished initializing.", hookFailed: "The global input hook is not running.",
+                queueTitle: "Input event queue", queueOk: "Processed {processed} events; peak queue {maxDepth}/{capacity}, with no drops.", queueDropped: "{dropped} input events were dropped; peak queue {maxDepth}/{capacity}.", queueBusy: "Peak input queue reached {maxDepth}/{capacity}; export another report after the issue occurs.",
+                modelsTitle: "OCR models", modelsOk: "Detection and recognition models loaded; dictionary contains {entries} entries.", modelsMissing: "OCR model files are incomplete.", modelsFailed: "OCR self-test failed: {error}",
+                displaysTitle: "Display enumeration", displaysOk: "Detected {count} displays; primary is {width}×{height} at {scale} scale.", displaysFailed: "Display check failed: {error}", displaysNone: "Windows did not return an available display.",
+                windowsTitle: "Window state", windowsOk: "Main window is healthy; overlay {overlay} and currently {lockState}.", windowsFailed: "The main window state is unavailable.", overlayOpen: "exists", overlayClosed: "has not been created (normal)", locked: "locked", unlocked: "unlocked",
+                updateTitle: "Update service", updateOk: "update.unsnow.online returned valid data; latest version {version}, {latency} ms.", updateFailed: "The update service is temporarily unavailable: {error}", updateInvalid: "The update service is reachable but returned invalid data: {error}",
+                unavailable: "unavailable", unknown: "unknown"
+            }
+        };
+
         const defaultStratagemDB = [
             { id:'wpn_mg', grp:'support', name:{zh:'MG-43 机枪',en:'MG-43 Machine Gun'}, aliases:[],ocr:['机枪'], seq:['S','A','S','W','D'] , icon: 'Machine_Gun_Stratagem_Icon.svg'},
             { id:'wpn_eat', grp:'support', name:{zh:'EAT-17 消耗性反坦克武器',en:'EAT-17 Expendable Anti-Tank'}, aliases:['筒子', '次抛', 'eat'],ocr:['消耗性反坦克武器'], seq:['S','S','A','W','D'], icon: 'Expendable_Anti-Tank_Stratagem_Icon.svg'},
@@ -1004,6 +1178,8 @@
         let isOverlayVisible = false; 
         let ocrDisplays = [];
         let pendingUpdateInfo = null;
+        let latestDiagnosticsReport = null;
+        let diagnosticsInFlight = null;
         
         let gameSettings = { 
             menuKey: 'ControlLeft', menuMode: 'hold', directionOnly: false, upKey: 'KeyW', downKey: 'KeyS', leftKey: 'KeyA', rightKey: 'KeyD',
@@ -1868,6 +2044,7 @@
             document.getElementById('opt-cat-mission').textContent = lang.cat_mission;
 
             document.getElementById('lib-search-input').placeholder = lang.searchPh;
+            updateDiagnosticsI18n();
             updateSettingsUI();
         }
 
@@ -2034,6 +2211,294 @@
                 showInlineStatus(`${i18n[currentLang].msgUpdateOpenFailed}: ${error}`, true);
             }
         }
+
+        // Diagnostics center helpers
+        function fillDiagnosticTemplate(template, values = {}) {
+            return Object.entries(values).reduce(
+                (text, [key, value]) => text.replaceAll(`{${key}}`, String(value)),
+                template
+            );
+        }
+
+        function buildDiagnosticChecks(report, language = currentLang) {
+            const lang = diagnosticsI18n[language] || diagnosticsI18n.en;
+            const checks = [];
+            const add = (section, status, title, summary) => checks.push({ section, status, title, summary });
+            const application = report.application || {};
+            const storage = report.storage || {};
+            const configuration = report.configuration || {};
+            const input = report.input || {};
+            const ocrStatus = report.ocr || {};
+            const update = report.updateService || {};
+            const windows = report.windows || {};
+
+            add('system', application.version ? 'ok' : 'warning', lang.runtimeTitle,
+                fillDiagnosticTemplate(lang.runtimeOk, {
+                    version: application.version || lang.unknown,
+                    arch: application.architecture || lang.unknown,
+                    webview: application.webviewVersion || lang.unavailable
+                }));
+
+            const validFiles = Array.isArray(storage.files)
+                ? storage.files.filter(file => file && file.status === 'valid').length
+                : 0;
+            add('system', storage.writable ? 'ok' : 'error', lang.storageTitle,
+                storage.writable
+                    ? fillDiagnosticTemplate(lang.storageOk, { valid: validFiles })
+                    : fillDiagnosticTemplate(lang.storageFailed, { error: storage.issue || lang.unknown }));
+
+            const invalidFiles = Number(storage.invalidFileCount) || 0;
+            add('system', invalidFiles > 0 ? 'error' : 'ok', lang.filesTitle,
+                invalidFiles > 0
+                    ? fillDiagnosticTemplate(lang.filesInvalid, {
+                        count: invalidFiles,
+                        recoverable: Number(storage.recoverableBackupCount) || 0
+                    })
+                    : lang.filesOk);
+
+            let configurationStatus = 'ok';
+            let configurationSummary = fillDiagnosticTemplate(lang.configOk, {
+                equipped: Number(configuration.equippedStratagems) || 0,
+                slots: Number(configuration.slotCount) || 0,
+                bound: Number(configuration.boundStratagems) || 0,
+                presets: Number(configuration.presetCount) || 0
+            });
+            if (!configuration.settingsLoaded) {
+                configurationStatus = 'warning';
+                configurationSummary = lang.configMissing;
+            } else if ((Number(configuration.duplicateBindingGroups) || 0) > 0) {
+                configurationStatus = 'warning';
+                configurationSummary = `${configurationSummary} ${fillDiagnosticTemplate(lang.configDuplicate, { count: configuration.duplicateBindingGroups })}`;
+            }
+            add('system', configurationStatus, lang.configTitle, configurationSummary);
+
+            const hookStatus = input.hookRunning ? (input.filterInitialized ? 'ok' : 'warning') : 'error';
+            add('input', hookStatus, lang.hookTitle,
+                !input.hookRunning ? lang.hookFailed : (input.filterInitialized ? lang.hookOk : lang.hookWaiting));
+
+            const dropped = Number(input.droppedEvents) || 0;
+            const maxDepth = Number(input.maxQueueDepth) || 0;
+            const capacity = Number(input.queueCapacity) || 0;
+            const queueBusy = capacity > 0 && maxDepth / capacity >= 0.8;
+            add('input', dropped > 0 || queueBusy ? 'warning' : 'ok', lang.queueTitle,
+                dropped > 0
+                    ? fillDiagnosticTemplate(lang.queueDropped, { dropped, maxDepth, capacity })
+                    : queueBusy
+                        ? fillDiagnosticTemplate(lang.queueBusy, { maxDepth, capacity })
+                        : fillDiagnosticTemplate(lang.queueOk, {
+                            processed: Number(input.processedEvents) || 0,
+                            maxDepth,
+                            capacity
+                        }));
+
+            const selfTest = ocrStatus.selfTest || {};
+            const modelValue = selfTest.value || {};
+            let modelStatus = 'ok';
+            let modelSummary = fillDiagnosticTemplate(lang.modelsOk, { entries: Number(modelValue.dictionaryEntries) || 0 });
+            if (!ocrStatus.modelFilesPresent) {
+                modelStatus = 'error';
+                modelSummary = lang.modelsMissing;
+            } else if (!selfTest.ok || !modelValue.detectionModelLoaded || !modelValue.recognitionModelLoaded) {
+                modelStatus = 'error';
+                modelSummary = fillDiagnosticTemplate(lang.modelsFailed, { error: selfTest.error || lang.unknown });
+            }
+            add('ocr', modelStatus, lang.modelsTitle, modelSummary);
+
+            const displayResult = ocrStatus.displays || {};
+            const displayValue = displayResult.value || {};
+            const displayCount = Number(displayValue.displayCount) || 0;
+            let displayStatus = 'ok';
+            let displaySummary = fillDiagnosticTemplate(lang.displaysOk, {
+                count: displayCount,
+                width: displayValue.primaryWidth || lang.unknown,
+                height: displayValue.primaryHeight || lang.unknown,
+                scale: Number(displayValue.primaryScaleFactor || 0).toFixed(2)
+            });
+            if (!displayResult.ok) {
+                displayStatus = 'error';
+                displaySummary = fillDiagnosticTemplate(lang.displaysFailed, { error: displayResult.error || lang.unknown });
+            } else if (displayCount === 0) {
+                displayStatus = 'error';
+                displaySummary = lang.displaysNone;
+            }
+            add('ocr', displayStatus, lang.displaysTitle, displaySummary);
+
+            add('services', windows.mainWindowExists ? 'ok' : 'error', lang.windowsTitle,
+                windows.mainWindowExists
+                    ? fillDiagnosticTemplate(lang.windowsOk, {
+                        overlay: windows.overlayWindowExists ? lang.overlayOpen : lang.overlayClosed,
+                        lockState: windows.overlayLocked ? lang.locked : lang.unlocked
+                    })
+                    : lang.windowsFailed);
+
+            let updateStatus = 'ok';
+            let updateSummary = fillDiagnosticTemplate(lang.updateOk, {
+                version: update.latestVersion || lang.unknown,
+                latency: Number(update.latencyMs) || 0
+            });
+            if (!update.reachable) {
+                updateStatus = 'warning';
+                updateSummary = fillDiagnosticTemplate(lang.updateFailed, { error: update.error || lang.unknown });
+            } else if (!update.validResponse) {
+                updateStatus = 'warning';
+                updateSummary = fillDiagnosticTemplate(lang.updateInvalid, { error: update.error || lang.unknown });
+            }
+            add('services', updateStatus, lang.updateTitle, updateSummary);
+            return checks;
+        }
+
+        function summarizeDiagnosticChecks(checks) {
+            return checks.reduce((summary, check) => {
+                if (check.status === 'ok') summary.healthy += 1;
+                if (check.status === 'warning') summary.warnings += 1;
+                if (check.status === 'error') summary.errors += 1;
+                return summary;
+            }, { healthy: 0, warnings: 0, errors: 0 });
+        }
+
+        function updateDiagnosticsI18n() {
+            const lang = diagnosticsI18n[currentLang];
+            document.getElementById('btn-top-diagnostics').textContent = lang.button;
+            document.getElementById('txt-diagnostics-title').textContent = lang.title;
+            document.getElementById('btn-diagnostics-refresh').textContent = lang.refresh;
+            document.getElementById('btn-diagnostics-close').textContent = lang.close;
+            document.getElementById('txt-diagnostics-lead').textContent = lang.lead;
+            document.getElementById('txt-diagnostics-description').textContent = lang.description;
+            document.getElementById('txt-diagnostics-privacy').textContent = lang.privacy;
+            document.getElementById('txt-diagnostics-ok').textContent = lang.healthy;
+            document.getElementById('txt-diagnostics-warning').textContent = lang.warnings;
+            document.getElementById('txt-diagnostics-error').textContent = lang.errors;
+            document.getElementById('diagnostics-running').textContent = lang.running;
+            document.getElementById('btn-diagnostics-copy').textContent = lang.copy;
+            document.getElementById('btn-diagnostics-export').textContent = lang.export;
+            if (latestDiagnosticsReport) {
+                renderDiagnostics(latestDiagnosticsReport);
+            } else {
+                document.getElementById('diagnostics-generated-at').textContent = lang.notRun;
+                document.getElementById('diagnostics-empty').textContent = lang.empty;
+            }
+        }
+
+        function setDiagnosticsRunning(running) {
+            document.getElementById('diagnostics-running').classList.toggle('active', running);
+            document.getElementById('diagnostics-modal').setAttribute('aria-busy', String(running));
+            document.getElementById('btn-diagnostics-refresh').disabled = running;
+            document.getElementById('btn-diagnostics-copy').disabled = running;
+            document.getElementById('btn-diagnostics-export').disabled = running;
+        }
+
+        function renderDiagnostics(report) {
+            const lang = diagnosticsI18n[currentLang];
+            const checks = buildDiagnosticChecks(report, currentLang);
+            const summary = summarizeDiagnosticChecks(checks);
+            report.healthSummary = summary;
+            document.getElementById('diagnostics-ok-count').textContent = summary.healthy;
+            document.getElementById('diagnostics-warning-count').textContent = summary.warnings;
+            document.getElementById('diagnostics-error-count').textContent = summary.errors;
+            const generatedAt = new Date(Number(report.generatedAtUnixMs) || Date.now());
+            document.getElementById('diagnostics-generated-at').textContent = fillDiagnosticTemplate(lang.generated, {
+                time: generatedAt.toLocaleString(currentLang === 'zh' ? 'zh-CN' : 'en-US')
+            });
+
+            const sectionTitles = {
+                system: lang.sectionSystem,
+                input: lang.sectionInput,
+                ocr: lang.sectionOcr,
+                services: lang.sectionServices
+            };
+            const sections = document.getElementById('diagnostics-sections');
+            sections.innerHTML = Object.entries(sectionTitles).map(([section, title]) => {
+                const rows = checks.filter(check => check.section === section).map(check => `
+                    <div class="diagnostics-check ${check.status}">
+                        <span class="diagnostics-check-dot" aria-hidden="true"></span>
+                        <div>
+                            <div class="diagnostics-check-title">${escapeHtml(check.title)}</div>
+                            <div class="diagnostics-check-summary">${escapeHtml(check.summary)}</div>
+                        </div>
+                    </div>`).join('');
+                return `<section class="diagnostics-section"><div class="diagnostics-section-title">${escapeHtml(title)}</div>${rows}</section>`;
+            }).join('');
+        }
+
+        async function collectDiagnostics() {
+            if (diagnosticsInFlight) return diagnosticsInFlight;
+            const lang = diagnosticsI18n[currentLang];
+            if (!window.electronAPI || typeof window.electronAPI.collectDiagnosticsReport !== 'function') {
+                showInlineStatus(fillDiagnosticTemplate(lang.runFailed, { error: 'IPC unavailable' }), true);
+                return null;
+            }
+            setDiagnosticsRunning(true);
+            diagnosticsInFlight = window.electronAPI.collectDiagnosticsReport()
+                .then(report => {
+                    latestDiagnosticsReport = report;
+                    renderDiagnostics(report);
+                    return report;
+                })
+                .catch(error => {
+                    showInlineStatus(fillDiagnosticTemplate(lang.runFailed, { error: String(error) }), true);
+                    return null;
+                })
+                .finally(() => {
+                    diagnosticsInFlight = null;
+                    setDiagnosticsRunning(false);
+                });
+            return diagnosticsInFlight;
+        }
+
+        window.openDiagnostics = () => {
+            window.closeModals();
+            document.getElementById('diagnostics-modal').classList.add('active');
+            updateDiagnosticsI18n();
+            void collectDiagnostics();
+        }
+
+        window.closeDiagnostics = () => {
+            document.getElementById('diagnostics-modal').classList.remove('active');
+        }
+
+        window.refreshDiagnostics = () => { void collectDiagnostics(); }
+
+        async function writeDiagnosticsClipboard(text) {
+            if (navigator.clipboard && navigator.clipboard.writeText) {
+                await navigator.clipboard.writeText(text);
+                return;
+            }
+            const textArea = document.createElement('textarea');
+            textArea.value = text;
+            textArea.style.position = 'fixed';
+            textArea.style.left = '-999999px';
+            document.body.appendChild(textArea);
+            textArea.focus();
+            textArea.select();
+            const copied = document.execCommand('copy');
+            textArea.remove();
+            if (!copied) throw new Error('Clipboard API unavailable');
+        }
+
+        window.copyDiagnosticsReport = async () => {
+            const lang = diagnosticsI18n[currentLang];
+            const report = latestDiagnosticsReport || await collectDiagnostics();
+            if (!report) return;
+            try {
+                await writeDiagnosticsClipboard(JSON.stringify(report, null, 2));
+                showInlineStatus(lang.copySuccess);
+            } catch (_error) {
+                showInlineStatus(lang.copyFailed, true);
+            }
+        }
+
+        window.exportDiagnosticsReport = async () => {
+            const lang = diagnosticsI18n[currentLang];
+            const report = latestDiagnosticsReport || await collectDiagnostics();
+            if (!report || !window.electronAPI || typeof window.electronAPI.exportDiagnosticsReport !== 'function') return;
+            try {
+                const result = await window.electronAPI.exportDiagnosticsReport(report);
+                showInlineStatus(fillDiagnosticTemplate(lang.exportSuccess, { filename: result.filename }));
+            } catch (error) {
+                showInlineStatus(fillDiagnosticTemplate(lang.exportFailed, { error: String(error) }), true);
+            }
+        }
+        // End diagnostics center helpers
 
         window.goSponsor = async () => {
             try {


### PR DESCRIPTION
## 改动说明

新增中英文诊断中心，将常见支持问题整理为一份结构化诊断报告。用户可以运行 10 项相互独立的健康检查、复制报告，或将经过隐私保护的 JSON 报告一键导出到“下载”目录；现有设置和启动行为不会发生改变。

## 问题与根因

目前用户反馈问题时缺少统一、可靠的运行环境信息。开发者往往需要逐项询问配置完整性、输入钩子状态、OCR 资源、显示器枚举、悬浮窗状态和更新服务连通性，用户也可能在提供信息时意外泄露个人路径或配置内容。

本功能提供由用户主动触发的诊断流程，并通过固定的隐私边界和受限的导出格式降低排查成本与信息泄露风险。

## 主要改动

- 新增原生诊断收集：应用与运行环境、存储可写性、JSON 完整性、脱敏配置统计、输入钩子计数、OCR 模型加载、显示器枚举、窗口状态以及更新服务健康状态。
- 磁盘、OCR、显示器和网络检查相互独立，并在 WebView 事件循环之外执行。
- 新增中英文诊断中心，展示正常、警告和错误汇总以及各子系统的详细结果。
- 新增复制报告及一键导出 JSON 到“下载”目录功能。
- 增加报告结构与大小校验、唯一文件名、持久化写入及失败后残留文件清理。
- 增加针对隐私保护、损坏文件、快捷键冲突、健康状态分类、IPC 接线和导出行为的 Rust 与 JavaScript 回归测试。

## 用户可见行为

主工具栏新增“诊断中心 / Diagnostics”按钮。打开后会启动检查，并按子系统展示 10 项健康结果。

该功能仅由用户手动触发，不改变启动和空闲时的行为。导出的报告不会包含用户名、完整路径、快捷键值、战备名称或截图。

## 兼容性与迁移

- 现有设置和保存数据：仅进行只读检查，不迁移结构，也不重写任何值。
- 从上一版本升级：现有设置、配装、预设、自定义战备和悬浮窗位置保持兼容。
- 现有用户的默认行为：保持不变，只有主动打开诊断中心后才会运行检查。
- 回滚或降级影响：无。导出的报告是独立 JSON 文件，旧版本会忽略这些文件。

## 测试

### 自动化检查

- [x] `npm run check`
- [x] `npm test`
- [x] 已为改动行为新增或更新针对性回归测试
- [x] `npm run build:bundle`（安装程序、发布、依赖、原生运行时或打包改动必须执行）

### 命令结果

| 命令 | 结果 | 说明 |
| --- | --- | --- |
| `npm run check` | 通过 | Rust 格式检查和 Clippy 均完成，警告按错误处理 |
| `npm test` | 通过 | Rust：65 项通过、0 项失败、6 项按设计忽略；UI 与 OCR 匹配器回归测试通过 |
| `npm run build:bundle` | 通过 | 已成功生成优化后的 x64 NSIS 安装程序 |

### 改动专项覆盖

- [x] 设置：缺失和损坏的配置文件、隐私安全摘要以及现有持久化兼容性
- [x] UI：中英文文本、加载与结果状态、失败分类、滚动和真实 Tauri/WebView2 行为
- [ ] 原生输入：本次未修改输入匹配或注入行为；现有完整原生输入回归测试已通过
- [ ] 悬浮窗与窗口：本次未修改悬浮窗行为；诊断功能只读取现有窗口状态
- [x] OCR：内置资源检查、真实模型加载、词典加载、显示器枚举、截图到文本回归流程和失败报告
- [x] 更新与网络：真实服务响应、超时与错误分类、响应校验、响应大小限制和安全文本渲染
- [ ] 安装与升级：安装程序已成功构建，但本功能 PR 未执行全新安装和覆盖安装
- [x] 性能与稳定性：诊断为按需执行，阻塞检查在工作线程运行，导出大小有上限，失败路径保留现有行为

### 测试矩阵

| 场景 | 环境与步骤 | 预期结果 | 实际结果 |
| --- | --- | --- | --- |
| 正常诊断流程 | Windows x64，在真实 Tauri WebView2 中打开诊断中心 | 10 项检查完成且窗口不被阻塞 | 10 项正常、0 项警告、0 项错误 |
| 中英文界面 | 在诊断窗口打开时切换语言 | 翻译完整且无横向溢出 | 两种语言均通过 |
| 隐私边界 | 检查原生报告和导出的 JSON | 不包含用户名、完整路径、按键值、战备名称或截图 | 通过；隐私标志均为 false，未检测到 Windows 路径 |
| JSON 导出 | 从真实 Release WebView 导出 | 在“下载”目录写入一份符合 schema-v1 的有效 JSON | 通过；导出报告可成功解析 |
| 配置损坏 | 使用配装 JSON 损坏的 Rust 测试夹具 | 报告无效文件，但不导出文件内容或路径 | 通过 |
| 离线或服务失败 | 使用更新服务不可达的 UI 健康状态夹具 | 显示警告，其他检查仍可正常使用 | 通过 |
| OCR 自检 | 加载内置运行时、模型和词典 | 检测与识别模型均显示加载成功 | 通过；词典共 18,384 项 |
| Release 打包 | 构建 x64 NSIS 目标 | 无打包错误并生成安装程序 | 通过 |

### 手动运行验证

- 环境：Windows x64、Tauri 调试版和优化后的 Release 可执行文件、WebView2 151.0.4129.78、单台 2560×1440 显示器。
- 执行步骤：通过 CDP 打开真实 WebView，运行诊断，核对所有分区和检查数量，切换中英文，检查溢出与控制台输出，执行 JSON 导出并解析导出文件，随后在优化后的 Release 可执行文件中重复健康检查。
- 观察结果：调试版和 Release 版均完成 10 项检查，结果为 10 项正常、0 项警告、0 项错误；无横向溢出，无控制台错误。

### 验证证据

- 真实诊断报告大小：2,536 字节。
- 真实更新服务结果：响应有效，最新版本为 2.0.1。
- NSIS 安装程序大小：24,087,410 字节。
- 安装程序 SHA-256：`E9CDBF73DDE9723DDF0CEBDA2460EC217BFB33FDAC54DBDA1869E3A1B4183DB2`。
- UI 与原生回归测试同时覆盖全正常状态以及警告、错误混合状态。

### 未执行检查与剩余风险

- 未执行全新安装以及覆盖上一版本的安装测试，因为本次改动没有修改安装钩子或持久化路径；安装程序构建本身已通过。
- 未进行真实操作系统断网测试；离线分类和各分区独立渲染已由回归测试覆盖。
- 未重新进行原生输入和悬浮窗手动操作验证，因为其执行路径未发生改变；现有自动化测试均已通过。

## 性能与稳定性影响

- 启动和空闲影响：无。只有用户打开诊断中心后才会运行检查。
- 热路径与并发影响：输入处理不变。磁盘、OCR、显示器和网络检查均在 WebView 事件循环之外并发执行。
- 失败与恢复行为：单项检查失败不会影响其他检查。导出大小限制为 256 KiB，不会覆盖现有文件，写入失败后会删除不完整文件。
- 性能数据：不宣称带来性能提升；真实诊断报告大小为 2,536 字节。

## 安全、隐私与网络影响

本次没有新增权限或服务端点。诊断网络探测复用现有 HTTPS 更新端点。报告只包含汇总数量和健康状态；已知本地根路径会被脱敏，配置内容不会被序列化，导出前会校验报告大小与结构。

存储可写性检查会在现有应用数据目录中创建并立即删除一个名称唯一的探测文件。导出功能只会在 Windows“下载”目录下写入程序生成名称的文件。

## 风险与回滚

- 风险：打开诊断中心会按设计加载 OCR 模型并执行一次有时限的网络请求，因此首次运行可能短暂增加内存占用；连接异常时可能需要等待设定的超时时间。
- 检测方式：诊断中心会显示每一项检查的错误；原生与 UI 测试以及真实 Release WebView 验证也覆盖相关回归。
- 回滚方式：回滚提交 `5806561`，无需迁移或清理数据。

## 关联 Issue

不适用。

## 最终检查清单

- [x] 分支基于当前 PR 目标分支，且不存在未解决冲突
- [x] 最终差异只包含预期的源代码和测试文件
- [x] 现有设置、配装、预设、自定义战备和悬浮窗位置保持兼容
- [x] 未包含密钥、私有配置、构建产物、临时辅助文件、调试代码或无关改动
- [x] 面向用户的中英文文本均已完整提供
- [x] 所有行为改动均有针对性回归测试覆盖
- [x] 所有适用的真实运行验证均已记录
- [x] 未验证行为与剩余风险均已明确说明
- [x] PR 标题和提交说明准确描述工程改动，不包含 AI 或工具品牌
