### PR TITLE
fix: reduce idle WebView resource usage

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hd2-macro-terminal-rust",
-  "version": "2.0.6",
+  "version": "2.0.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hd2-macro-terminal-rust",
-      "version": "2.0.6",
+      "version": "2.0.7",
       "devDependencies": {
         "@tauri-apps/cli": "^2.11.4"
       }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hd2-macro-terminal-rust",
-  "version": "2.0.6",
+  "version": "2.0.7",
   "private": true,
   "scripts": {
     "tauri": "set \"PATH=%USERPROFILE%\\.cargo\\bin;%PATH%\" && tauri",

--- a/scripts/ui-regression.mjs
+++ b/scripts/ui-regression.mjs
@@ -33,6 +33,7 @@ const ocrHelpSource = readUiFile("ocr-help.html");
 const mainSource = fs.readFileSync(path.join(root, "src-tauri", "src", "main.rs"), "utf8");
 const hooksSource = fs.readFileSync(path.join(root, "src-tauri", "src", "hooks.rs"), "utf8");
 const inputSource = fs.readFileSync(path.join(root, "src-tauri", "src", "input.rs"), "utf8");
+const windowsSource = fs.readFileSync(path.join(root, "src-tauri", "src", "windows.rs"), "utf8");
 const runtimeDiagnosticsSource = fs.readFileSync(path.join(root, "src-tauri", "src", "runtime_diagnostics.rs"), "utf8");
 const updatesSource = fs.readFileSync(path.join(root, "src-tauri", "src", "updates.rs"), "utf8");
 const networkSource = fs.readFileSync(path.join(root, "src-tauri", "src", "network.rs"), "utf8");
@@ -85,12 +86,12 @@ const tauriConfig = JSON.parse(
 );
 const installerHooks = tauriConfig.bundle?.windows?.nsis?.installerHooks;
 assert.equal(installerHooks, "windows/installer-hooks.nsh");
-assert.equal(tauriConfig.version, "2.0.6", "the bundled version must match the application version");
+assert.equal(tauriConfig.version, "2.0.7", "the bundled version must match the application version");
 const packageJson = JSON.parse(fs.readFileSync(path.join(root, "package.json"), "utf8"));
 const packageLock = JSON.parse(fs.readFileSync(path.join(root, "package-lock.json"), "utf8"));
-assert.equal(packageJson.version, "2.0.6");
-assert.equal(packageLock.version, "2.0.6");
-assert.equal(packageLock.packages[""].version, "2.0.6");
+assert.equal(packageJson.version, "2.0.7");
+assert.equal(packageLock.version, "2.0.7");
+assert.equal(packageLock.packages[""].version, "2.0.7");
 const installerHookSource = fs.readFileSync(path.join(root, "src-tauri", installerHooks), "utf8");
 assert.match(installerHookSource, /CheckIfAppIsRunning "HD2 Macro Terminal\.exe"/);
 assert.match(installerHookSource, /CheckIfAppIsRunning "HD2-Trigger\.exe"/);
@@ -113,6 +114,27 @@ for (const command of [
     `${command} must stay async because it can create a WebView window on Windows`,
   );
 }
+
+assert.match(
+  indexSource,
+  /\.modal-overlay\s*{[\s\S]{0,500}visibility:\s*hidden;[\s\S]{0,500}\.modal-overlay\.active\s*{[^}]*visibility:\s*visible;/,
+  "inactive full-window blur layers must be excluded from rendering",
+);
+assert.match(
+  indexSource,
+  /#global-status\s*{[\s\S]{0,500}visibility:\s*hidden;[\s\S]{0,500}#global-status\.show\s*{[^}]*visibility:\s*visible;/,
+  "the hidden status blur layer must be excluded from rendering",
+);
+assert.match(
+  mainSource,
+  /if windows::overlay_is_visible\(&app\)\?\s*{[\s\S]{0,300}persist_current_overlay_position\(&app\)\?;[\s\S]{0,200}destroy_window\(&app, "overlay"\)\?;/,
+  "overlay position must be persisted before its idle WebView is destroyed",
+);
+assert.match(
+  windowsSource,
+  /pub fn hide_toast[\s\S]{0,500}window\.destroy\(\)/,
+  "expired toast WebViews must release their renderer instead of remaining hidden",
+);
 
 const helperStart = indexSource.indexOf("const CANONICAL_GLOBAL_KEYS");
 const helperEnd = indexSource.indexOf("function normalizeOverlayPosition", helperStart);

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1454,7 +1454,7 @@ checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
 name = "hd2-macro-terminal-rust"
-version = "2.0.6"
+version = "2.0.7"
 dependencies = [
  "base64 0.22.1",
  "ed25519-dalek",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hd2-macro-terminal-rust"
-version = "2.0.6"
+version = "2.0.7"
 description = "A lightweight Windows x64 rewrite of HD2 Macro Terminal"
 authors = ["Huizhixin"]
 edition = "2021"

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -348,12 +348,16 @@ async fn toggle_overlay(app: AppHandle, state: State<'_, AppState>) -> Result<bo
         .window_creation
         .lock()
         .map_err(|_| "Window creation is unavailable".to_owned())?;
-    let saved_position = load_overlay_position(&state.data_dir)?;
-    let visible = windows::toggle_overlay(&app, saved_position)?;
-    if !visible {
+    if windows::overlay_is_visible(&app)? {
+        // Persist first so a storage failure leaves the still-live overlay in
+        // a state the renderer can accurately report and retry.
         persist_current_overlay_position(&app)?;
+        windows::destroy_window(&app, "overlay")?;
+        return Ok(false);
     }
-    Ok(visible)
+    let saved_position = load_overlay_position(&state.data_dir)?;
+    windows::show_overlay(&app, saved_position)?;
+    Ok(true)
 }
 
 #[tauri::command]

--- a/src-tauri/src/windows.rs
+++ b/src-tauri/src/windows.rs
@@ -136,21 +136,22 @@ fn create_ocr_select_window(
     Ok(window)
 }
 
-pub fn toggle_overlay(
+pub fn overlay_is_visible(app: &AppHandle) -> Result<bool, String> {
+    app.get_webview_window("overlay")
+        .map(|window| window.is_visible().map_err(|error| error.to_string()))
+        .transpose()
+        .map(|visible| visible.unwrap_or(false))
+}
+
+pub fn show_overlay(
     app: &AppHandle,
     saved_position: Option<OverlayPosition>,
-) -> Result<bool, String> {
+) -> Result<(), String> {
     let window = ensure_overlay_window(app)?;
-    let visible = window.is_visible().map_err(|error| error.to_string())?;
-    if visible {
-        window.hide().map_err(|error| error.to_string())?;
-    } else {
-        if let Some(position) = saved_position {
-            set_window_position(&window, position)?;
-        }
-        window.show().map_err(|error| error.to_string())?;
+    if let Some(position) = saved_position {
+        set_window_position(&window, position)?;
     }
-    Ok(!visible)
+    window.show().map_err(|error| error.to_string())
 }
 
 pub fn minimize_main(app: &AppHandle) -> Result<(), String> {
@@ -348,7 +349,10 @@ fn toast_height(payload: &serde_json::Value) -> f64 {
 
 pub fn hide_toast(app: &AppHandle) -> Result<(), String> {
     if let Some(window) = app.get_webview_window("toast") {
-        window.hide().map_err(|error| error.to_string())?;
+        // Toasts are infrequent and already restore their latest payload when
+        // recreated. Destroying the transparent WebView releases its renderer
+        // and GPU composition resources instead of retaining them while idle.
+        window.destroy().map_err(|error| error.to_string())?;
     }
     Ok(())
 }

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "HD2 Macro Terminal Rust",
-  "version": "2.0.6",
+  "version": "2.0.7",
   "identifier": "com.hd2.trigger.rust",
   "build": {
     "frontendDist": "../ui",

--- a/ui/index.html
+++ b/ui/index.html
@@ -196,9 +196,10 @@
             position: fixed; top: 40px; left: 0; width: 100%; height: calc(100% - 40px);
             background: rgba(0,0,0,0.4); backdrop-filter: blur(15px); -webkit-backdrop-filter: blur(15px);
             z-index: 50; display: flex; flex-direction: column;
-            opacity: 0; pointer-events: none; transition: opacity 0.3s ease;
+            opacity: 0; visibility: hidden; pointer-events: none;
+            transition: opacity 0.3s ease, visibility 0s linear 0.3s;
         }
-        .modal-overlay.active { opacity: 1; pointer-events: auto; }
+        .modal-overlay.active { opacity: 1; visibility: visible; pointer-events: auto; transition-delay: 0s; }
         
         .modal-header {
             padding: 20px 24px; border-bottom: 1px solid var(--glass-border); display: flex;
@@ -296,11 +297,11 @@
             position: fixed; bottom: 30px; left: 50%; transform: translate(-50%, 30px);
             background: rgba(255, 232, 10, 0.9); backdrop-filter: blur(10px); color: var(--hd-black);
             padding: 12px 24px; font-size: 14px; font-weight: bold; border-radius: 30px; z-index: 999;
-            opacity: 0; transition: var(--transition); pointer-events: none;
+            opacity: 0; visibility: hidden; transition: opacity 0.3s ease, transform 0.3s ease, visibility 0s linear 0.3s; pointer-events: none;
             box-shadow: 0 10px 30px rgba(0,0,0,0.5); border: 1px solid rgba(255,255,255,0.2);
             text-align: center; white-space: nowrap;
         }
-        #global-status.show { opacity: 1; transform: translate(-50%, 0); }
+        #global-status.show { opacity: 1; visibility: visible; transform: translate(-50%, 0); transition-delay: 0s; }
         #global-status.error { background: rgba(255, 69, 58, 0.9); color: white; }
 
         .confirm-box {


### PR DESCRIPTION
## 改动说明

针对 Issue #20 中反馈的运行性能问题，减少程序空闲时不必要的 WebView2 渲染与透明毛玻璃合成开销，并将版本更新为 2.0.7。

## 主要改动

- 悬浮窗关闭后释放闲置渲染资源，重新打开时恢复原有内容、选中项、样式、锁定状态和保存位置。
- 通知提示淡出后释放对应渲染资源。
- 未显示的模态窗口与状态提示不再参与页面合成。
- 保持 OCR、快捷键、战备输入、热更新与现有设置行为不变。

## 兼容性

- 现有设置、战备配置、预设、自定义战备和悬浮窗位置无需迁移。
- 不新增开关，不改变默认行为。
- OCR 仍按需运行，未修改识别流程。

## 测试

- [x] `npm run check`：通过，Clippy 零警告。
- [x] `npm test`：通过，Rust 73 项通过、7 项环境测试忽略；管理后台 18/18 通过；UI、OCR 与图标回归通过。
- [x] 真实 Tauri/WebView2 开关悬浮窗三轮，内容、锁定状态、选中项和位置恢复正常。
- [x] 通知窗口显示、淡出、销毁和再次创建正常。
- [x] 15 秒空闲 GPU 采样平均值与峰值均为 0%。

## 风险与回滚

本次只调整闲置窗口生命周期和隐藏图层渲染状态。如需回滚，可直接回退本 PR 提交。当前环境未运行游戏，Issue #20 报告者的游戏内帧率变化仍需实际游戏环境确认。

关联：#20